### PR TITLE
refactor: move dataset loading from driver into AsyncTrainingController

### DIFF
--- a/tests/test_capacity_handling.py
+++ b/tests/test_capacity_handling.py
@@ -114,6 +114,7 @@ class MockControllerArgs:
     """Mock args for AsyncTrainingController."""
 
     dispatch_batch_size: int = 4
+    eval_dispatch_batch_size: int = 4
 
 
 def _create_mock_inference_output(


### PR DESCRIPTION
## Summary

- Move dataset loading from driver process into `AsyncTrainingController` Ray actor, eliminating the large data serialization overhead of `ray.put(dataset)`
- Controller loads dataset asynchronously while driver runs independent initialization (placement groups, mooncake, config) in parallel
- `run_training_loop` no longer takes `dataset_ref`/`eval_dataset`; replaced with `dataset_size`/`eval_dataset_size` int parameters
- `setup_async_training_with_engines` accepts an optional pre-created controller (backward compatible)
- Fix pre-existing test failure: add missing `eval_dispatch_batch_size` field to `MockControllerArgs`

## Test plan

- [x] `pytest tests/ -v` — 189 passed, 0 failed, 4 skipped (fixes 14 pre-existing failures)
- [x] End-to-end training test: run full training loop with existing example config to verify epoch reload, eval, and vocab mapping work correctly