### PR TITLE
support formatted text without input_ids to skip tokenization

### DIFF
--- a/torchspec/controller/training_controller.py
+++ b/torchspec/controller/training_controller.py
@@ -169,11 +169,19 @@ class AsyncTrainingController:
             for sample in dataset:
                 if isinstance(sample, dict):
                     data_id = sample.get("data_id") or self._generate_data_id()
+                    input_ids = sample.get("input_ids")
+                    packed_loss_mask = sample.get("packed_loss_mask")
+                    if input_ids is not None and packed_loss_mask is None:
+                        raise ValueError(
+                            f"packed_loss_mask is required when input_ids is provided "
+                            f"(data_id={data_id}). Use defer_tokenization=True to skip "
+                            f"tokenization entirely."
+                        )
                     entry = InferenceInput(
                         data_id=data_id,
                         prompt=sample.get("prompt", sample),
-                        input_ids=sample.get("input_ids"),
-                        packed_loss_mask=sample.get("packed_loss_mask"),
+                        input_ids=input_ids,
+                        packed_loss_mask=packed_loss_mask,
                         formatted_prompt=sample.get("formatted_prompt"),
                         metadata=sample.get("metadata", {}),
                         multimodal_inputs=sample.get("multimodal_inputs"),

--- a/torchspec/data/dataset.py
+++ b/torchspec/data/dataset.py
@@ -34,7 +34,6 @@ from torchspec.data.utils import (
     flatten_multimodal_content,
     load_hf_dataset,
 )
-from torchspec.data.parse import create_parser
 from torchspec.utils.logging import logger
 
 _logging.getLogger("transformers_modules").setLevel(_logging.ERROR)
@@ -82,10 +81,14 @@ def _tokenize_single(args):
     }
 
 
-def _init_format_worker(chat_template_name):
+def _init_format_worker(tokenizer_path, trust_remote_code, chat_template_name):
+    from torchspec.data.parse import create_parser
+    from torchspec.utils.processing import load_tokenizer
+
     _logging.getLogger("transformers_modules").setLevel(_logging.ERROR)
+    tokenizer = load_tokenizer(tokenizer_path, trust_remote_code=trust_remote_code)
     _worker_state["template"] = TEMPLATE_REGISTRY.get(chat_template_name)
-    _worker_state["parser"] = create_parser(None, _worker_state["template"])
+    _worker_state["parser"] = create_parser(tokenizer, _worker_state["template"])
 
 
 def _format_single(args):
@@ -173,20 +176,24 @@ def load_conversation_dataset(args):
         data_id = sample.get("id", f"sample_{idx}")
         raw_samples.append((data_id, messages, multimodal_inputs))
 
-    logger.info(f"Loaded {len(raw_samples)} samples, {mode_label.lower()} with {num_proc} workers...")
+    logger.info(
+        f"Loaded {len(raw_samples)} samples, {mode_label.lower()} with {num_proc} workers..."
+    )
 
     # Pass 2: process in parallel
     work_items = [(messages, max_length) for _, messages, _ in raw_samples]
 
     if defer_tokenization:
         worker_init = _init_format_worker
-        worker_initargs = (chat_template_name,)
+        worker_initargs = (args.target_model_path, True, chat_template_name)
         worker_fn = _format_single
         desc = "Formatting dataset"
     else:
         last_turn_loss_only = getattr(args, "last_turn_loss_only", False)
         if last_turn_loss_only:
-            logger.info("last_turn_loss_only=True: loss mask will only cover the last assistant turn")
+            logger.info(
+                "last_turn_loss_only=True: loss mask will only cover the last assistant turn"
+            )
         worker_init = _init_tokenize_worker
         worker_initargs = (args.target_model_path, True, chat_template_name, last_turn_loss_only)
         worker_fn = _tokenize_single

--- a/torchspec/inference/engine/sgl_engine.py
+++ b/torchspec/inference/engine/sgl_engine.py
@@ -423,21 +423,13 @@ class SglEngine(InferenceEngine, RayActor):
                 seq_len = result["meta_info"].get("prompt_tokens")
                 if seq_len is None:
                     if use_prompts:
-                        logger.warning(
+                        raise RuntimeError(
                             f"SglEngine rank {self.rank}: 'prompt_tokens' missing from "
-                            f"meta_info for data_id={data_ids[i]}; cannot reliably "
-                            f"determine seq_len from formatted_prompts (char count != token count)."
+                            f"meta_info for data_id={data_ids[i]}. The engine must report "
+                            f"prompt_tokens when using formatted_prompts (defer_tokenization mode)."
                         )
-                        seq_len = 0
                     else:
                         seq_len = len(input_ids_list_of_lists[i])
-
-                if seq_len == 0:
-                    logger.debug(
-                        f"SglEngine rank {self.rank}: skipping mooncake_key={key} "
-                        f"with seq_len=0 for data_id={data_ids[i]}"
-                    )
-                    continue
 
                 tensor_shapes = self._get_tensor_shapes(seq_len)
                 logger.debug(


### PR DESCRIPTION
## Summary
See issue #16, in short, if we use token_ids for multimodal case, we will need to decode from input_ids and convert it back to regular text. This leads to unnecessary tokenization. 

We can simply leverage inference engine's internal tokenization and feed it with raw formatted prompt. Then rely ofn engine's own --allow-auto-truncate and --context-length to control the truncation. Loss mask is calculated based on the input_ids returned.


The ultimate reason we need this is because we can't know ahead of time how many tokens the multimodal ViT is going to expand the tokens to. Thus, the pre-calculated loss mask is useless. We always need generate during training time.

## Testing

Locally running without issue

```
Training:  25%|██▍       | 4957/19848 [03:03<9:02:36,  2.19s/step, loss=0.759, acc=0.858, acc_len=2.87, thru=5.0, I=5.0, T=5.3, wait=0Training:  25%|██▍       | 4958/19848 [03:04<6:53:22,  1.67s/step, loss=0.719, acc=0.861, acc_len=2.90, thru=5.2, I=5.0, T=19.0, wait=Training:  25%|██▍       | 4959/19848 [03:05<5:51:15,  1.42s/step, loss=0.539, acc=0.891, acc_len=3.13, thru=5.4, I=4.9, T=10.0, wait=Training:  25%|██▍       | 4960/19848 [03:06<5:55:46,  1.43s/step, loss=0.921, acc=0.784, acc_len=2.46, thru=5.1, I=4.9, T=5.5, wait=0
```