### PR TITLE
Fix: cap eval_dispatch_bs at eval_dataset_size

### DIFF
--- a/torchspec/controller/eval.py
+++ b/torchspec/controller/eval.py
@@ -160,7 +160,7 @@ def setup_eval(controller, train_group, args, eval_dataset_size: int) -> EvalSet
     eval_cache_path: str | None = None
     eval_cache_loaded = False
 
-    eval_dispatch_bs = args.dp_size
+    eval_dispatch_bs = min(args.dp_size, eval_dataset_size)
 
     best_eval_score = -float("inf")
     if eval_enabled and args.checkpoint_dir:


### PR DESCRIPTION
## Summary
- `eval_dispatch_bs` was set to `dp_size` without considering the actual dataset size, causing it to exceed `eval_dataset_size` when the dataset is smaller than `dp_size`
- Fix: use `min(dp_size, eval_dataset_size)` to cap the value

## Test plan
- [x] `test_setup_eval_dispatch_bs_caps_at_dataset_size` now passes
- [x] `test_setup_eval_dispatch_bs_is_dp_size` still passes (dp_size <= dataset_size case)