### PR TITLE
feat: add train_with_decode support for speculative decoding during training

### DIFF
--- a/configs/train_with_decode/sglang_kimi_k25_nvfp4.yaml
+++ b/configs/train_with_decode/sglang_kimi_k25_nvfp4.yaml
@@ -1,0 +1,103 @@
+# Kimi-K2.5 NVFP4 Eagle3 online training (train with decode mode)
+#
+# This extends the regular Kimi training to enable EAGLE3 speculative decoding:
+# the sgl.Engine loads both target and draft models, generates tokens with
+# speculative decoding, and captures hidden states during the full sequence
+# (prefill + decode) for training.
+#
+# GPU allocation:
+#   - 4 GPUs for inference (1 engine x TP=4, target + draft model)
+#   - 2 GPUs for training (FSDP/DP across 2 GPUs)
+#   - Total: 6 GPUs
+#
+# Usage:
+#   python -m torchspec.train_entry \
+#       --config configs/train_with_decode/sglang_kimi_k25_nvfp4.yaml
+
+model:
+  target_model_path: nvidia/Kimi-K2.5-NVFP4
+  trust_remote_code: true
+  lm_head_key: language_model.lm_head.weight
+  embedding_key: language_model.model.embed_tokens.weight
+  draft_model_config: configs/draft_models/kimi_k25_eagle3.json
+
+dataset:
+  train_data_path: liuhaotian/LLaVA-Instruct-150K
+  chat_template: kimi-k25-vlm
+  prompt_key: conversations
+
+training:
+  max_seq_length: 8192
+  seed: 42
+  micro_batch_size: 2
+  num_epochs: 1
+  save_interval: 500
+  learning_rate: 1e-4
+  warmup_ratio: 0.0
+  max_grad_norm: 1
+  ttt_length: 5
+  draft_accumulation_steps: 1
+  training_num_nodes: 1
+  training_num_gpus_per_node: 2
+  train_with_decode: true
+  attention_backend: flex_attention
+  max_concurrent_batches: 1
+  gradient_checkpointing: true
+
+inference:
+  inference_engine_type: sgl
+  inference_num_gpus: 4
+  inference_num_gpus_per_engine: 4
+  inference_num_gpus_per_node: 6
+  max_sample_pool_size: 64
+  inference_buffer_threshold: 8
+  inference_batch_size: 8
+  sglang:
+    tp_size: 4
+    mem_fraction_static: 0.85
+    enable_multimodal: true
+    init_timeout: 1000
+    extra_args:
+      quantization: modelopt_fp4
+      kv_cache_dtype: fp8_e4m3
+      context_length: 262144
+      attention_backend: trtllm_mla
+      moe_runner_backend: flashinfer_trtllm
+      model_loader_extra_config:
+        enable_multithread_load: true
+        num_threads: 119
+      disable_flashinfer_autotune: true
+      disable_cuda_graph: false
+      log_requests: true
+      log_requests_level: 0
+      speculative_draft_attention_backend: flashinfer
+
+decode:
+  max_new_tokens: 512
+  temperature: 1.0
+  speculative_algorithm: EAGLE3
+  speculative_draft_model_path: null  # Auto-created from target model
+  speculative_num_steps: 5
+  speculative_eagle_topk: 1
+  speculative_num_draft_tokens: 6
+  weight_sync_enabled: true
+  weight_sync_interval: 10
+  cuda_graph_max_bs: 8
+  max_running_requests: 8
+
+mooncake:
+  master_server_address: null
+  metadata_server: null
+  protocol: tcp
+  hidden_dim: 7168
+  global_segment_size: 16GB
+  local_buffer_size: 4GB
+
+output_dir: ./outputs/kimi_k25_nvfp4_decode
+cache_dir: ./cache/kimi_k25_nvfp4_decode
+model_download_dir: null
+
+debug:
+  save_debug_train_data: null
+  debug_train_only: false
+  debug_inference_only: false

--- a/configs/train_with_decode/sglang_qwen3_8b.yaml
+++ b/configs/train_with_decode/sglang_qwen3_8b.yaml
@@ -1,0 +1,79 @@
+# Configuration for train_entry.py with SglEngine in decode mode (speculative decoding)
+#
+# This extends the prefill-only SglEngine config to enable EAGLE3 speculative
+# decoding: the sgl.Engine loads both target and draft models, generates tokens
+# with speculative decoding, and captures hidden states during the full sequence
+# (prefill + decode) for training.
+#
+# GPU allocation:
+#   - 1 GPU  for inference (SglEngine with TP=1, loads target + draft model)
+#   - 2 GPUs for training (FSDP/DP: draft model sharded across 2 GPUs)
+#   - Total: 3 GPUs
+#
+# Usage:
+#   python -m torchspec.train_entry --config configs/train_with_decode/sglang_qwen3_8b.yaml
+
+model:
+  target_model_path: Qwen/Qwen3-8B
+  trust_remote_code: true
+
+dataset:
+  train_data_path: ../../examples/data/sample_conversations.jsonl
+  chat_template: qwen
+  prompt_key: conversations
+
+training:
+  attention_backend: flex_attention
+  micro_batch_size: 2
+  draft_accumulation_steps: 1
+  learning_rate: 1e-4
+  max_concurrent_batches: 1
+  max_grad_norm: 2.5
+  max_seq_length: 2048
+  num_epochs: 1
+  seed: 42
+  train_with_decode: true
+  training_num_gpus_per_node: 2
+  training_num_nodes: 1
+  ttt_length: 5
+  warmup_ratio: 0.0
+
+inference:
+  inference_engine_type: sgl
+  inference_num_gpus: 1
+  inference_num_gpus_per_engine: 1
+  inference_num_gpus_per_node: 1
+  aux_hidden_states_layers: [2, 4, 6]
+  max_sample_pool_size: 200
+  inference_buffer_threshold: 32
+  inference_batch_size: 12
+  sglang:
+    tp_size: 1
+    mem_fraction_static: 0.7
+
+decode:
+  max_new_tokens: 512
+  temperature: 1.0
+  speculative_algorithm: EAGLE3
+  speculative_draft_model_path: null  # Auto-created from target model
+  speculative_num_steps: 5
+  speculative_eagle_topk: 1
+  speculative_num_draft_tokens: 6
+  weight_sync_enabled: true
+  weight_sync_interval: 15
+
+mooncake:
+  master_server_address: null
+  metadata_server: null
+  protocol: tcp
+  global_segment_size: 16GB
+  local_buffer_size: 4GB
+
+output_dir: ./outputs/qwen3-8b-decode
+cache_dir: ./cache/qwen3-8b-decode
+model_download_dir: null
+
+debug:
+  save_debug_train_data: null
+  debug_train_only: false
+  debug_inference_only: false

--- a/examples/train-with-decode/run_kimi_k25_nvfp4.sh
+++ b/examples/train-with-decode/run_kimi_k25_nvfp4.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Launch torchspec.train_entry for Kimi-K2.5 NVFP4 Eagle3 decode-mode training
+#
+# GPU allocation (default: 6 GPUs on single node):
+#   - 4 GPUs for inference (SglEngine TP=4, target + draft model with NVFP4 quantization)
+#   - 2 GPUs for training (FSDP/DP: draft model sharded across 2 GPUs)
+#
+# Usage:
+#   ./examples/train-with-decode/run_kimi_k25_nvfp4.sh [extra_overrides...]
+#
+# Environment variables:
+#   CUDA_VISIBLE_DEVICES — GPUs to use (default: 0,1,2,3,4,5)
+#   TRAIN_GPUS           — GPUs for training (default: 2)
+#   INFERENCE_GPUS       — GPUs for inference (default: 4)
+#   CONFIG_FILE          — Override config file path
+
+set -euo pipefail
+set -x
+
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0,1,2,3,4,5}
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+export TORCHINDUCTOR_CACHE_DIR="$ROOT_DIR/cache/compiled_kernels"
+export SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1
+export SGLANG_DISABLE_CUDNN_CHECK=1
+export TORCHSPEC_LOG_LEVEL=INFO
+
+TRAIN_GPUS="${TRAIN_GPUS:-2}"
+INFERENCE_GPUS="${INFERENCE_GPUS:-4}"
+
+CONFIG_FILE="${CONFIG_FILE:-$ROOT_DIR/configs/train_with_decode/sglang_kimi_k25_nvfp4.yaml}"
+
+IFS=',' read -ra GPU_ARRAY <<< "$CUDA_VISIBLE_DEVICES"
+TOTAL_GPUS=${#GPU_ARRAY[@]}
+
+LOG_DIR="$ROOT_DIR/running_logs"
+mkdir -p "$LOG_DIR"
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+LOG_FILE="$LOG_DIR/kimi25_nvfp4_decode_${TIMESTAMP}.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+echo "Logging to: $LOG_FILE"
+
+echo "=============================================="
+echo "Kimi-K2.5 NVFP4 Decode-Mode Training"
+echo "=============================================="
+echo "Config:          $CONFIG_FILE"
+echo "Total GPUs:      $TOTAL_GPUS (CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES)"
+echo "  Training GPUs:  $TRAIN_GPUS (FSDP/DP)"
+echo "  Inference GPUs: $INFERENCE_GPUS (SglEngine TP=$INFERENCE_GPUS, NVFP4 quantization)"
+echo "Extra args: $*"
+echo "=============================================="
+
+python3 -m torchspec.train_entry \
+    --config "$CONFIG_FILE" \
+    training.training_num_gpus_per_node="$TRAIN_GPUS" \
+    inference.inference_engine_type="sgl" \
+    inference.inference_num_gpus="$INFERENCE_GPUS" \
+    inference.inference_num_gpus_per_engine="$INFERENCE_GPUS" \
+    inference.inference_num_gpus_per_node="$TOTAL_GPUS" \
+    inference.sglang.tp_size="$INFERENCE_GPUS" \
+    model.draft_model_config="$ROOT_DIR/configs/draft_models/kimi_k25_eagle3.json" \
+    "$@"
+
+echo "=============================================="
+echo "Training completed!"
+echo "=============================================="

--- a/examples/train-with-decode/run_qwen3_8b.sh
+++ b/examples/train-with-decode/run_qwen3_8b.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Train with SglEngine in decode mode (speculative decoding)
+#
+# GPU allocation (default: 3 GPUs total):
+#   - 1 GPU  for inference (SglEngine with TP=1, loads target + draft model)
+#   - 2 GPUs for training (FSDP/DP: draft model sharded across 2 GPUs)
+#
+# Usage:
+#   ./examples/train-with-decode/run_qwen3_8b.sh [CONFIG_FILE] [EXTRA_ARGS...]
+#
+# Examples:
+#   # Run with default decode config
+#   ./examples/train-with-decode/run_qwen3_8b.sh
+#
+#   # Run with custom config
+#   ./examples/train-with-decode/run_qwen3_8b.sh configs/train_with_decode/sglang_qwen3_8b.yaml
+#
+#   # Run with extra args
+#   ./examples/train-with-decode/run_qwen3_8b.sh configs/train_with_decode/sglang_qwen3_8b.yaml training.num_train_steps=10
+
+set -euo pipefail
+set -x
+
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0,1,2}
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+export TORCHINDUCTOR_CACHE_DIR="$ROOT_DIR/cache/compiled_kernels"
+export TORCHSPEC_LOG_LEVEL=INFO
+
+CONFIG_FILE="${1:-$ROOT_DIR/configs/train_with_decode/sglang_qwen3_8b.yaml}"
+if [[ -f "$CONFIG_FILE" ]]; then
+    shift 1 || true
+elif [[ -f "$ROOT_DIR/$CONFIG_FILE" ]]; then
+    CONFIG_FILE="$ROOT_DIR/$CONFIG_FILE"
+    shift 1 || true
+else
+    CONFIG_FILE="$ROOT_DIR/configs/train_with_decode/sglang_qwen3_8b.yaml"
+fi
+
+IFS=',' read -ra GPU_ARRAY <<< "$CUDA_VISIBLE_DEVICES"
+TOTAL_GPUS=${#GPU_ARRAY[@]}
+
+TRAIN_GPUS=2
+INFERENCE_GPUS=1
+
+echo "=============================================="
+echo "Train with SglEngine decode (speculative decoding)"
+echo "=============================================="
+echo "Config: $CONFIG_FILE"
+echo "Total GPUs: $TOTAL_GPUS (CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES)"
+echo "  - Training GPUs: $TRAIN_GPUS (FSDP/DP - model sharded)"
+echo "  - Inference GPUs: $INFERENCE_GPUS (SglEngine TP=1, target + draft model)"
+echo "Extra args: $*"
+echo "=============================================="
+
+python3 -m torchspec.train_entry \
+    --config "$CONFIG_FILE" \
+    training.training_num_gpus_per_node="$TRAIN_GPUS" \
+    inference.inference_engine_type="sgl" \
+    inference.inference_num_gpus="$INFERENCE_GPUS" \
+    inference.inference_num_gpus_per_engine="$INFERENCE_GPUS" \
+    inference.inference_num_gpus_per_node="$TOTAL_GPUS" \
+    inference.sglang.tp_size="$INFERENCE_GPUS" \
+    "$@"
+
+echo "=============================================="
+echo "Training completed!"
+echo "=============================================="

--- a/patches/sglang/v0.5.8.post1/sglang_decode.patch
+++ b/patches/sglang/v0.5.8.post1/sglang_decode.patch
@@ -1,0 +1,1615 @@
+diff --git a/python/sglang/srt/entrypoints/engine.py b/python/sglang/srt/entrypoints/engine.py
+index 8d7ab8716..b2e633016 100644
+--- a/python/sglang/srt/entrypoints/engine.py
++++ b/python/sglang/srt/entrypoints/engine.py
+@@ -233,6 +233,9 @@ class Engine(EngineBase):
+         data_parallel_rank: Optional[int] = None,
+         external_trace_header: Optional[Dict] = None,
+         rid: Optional[Union[List[str], str]] = None,
++        # Speculative training fields
++        spec_training_data_id: Optional[Union[List[str], str]] = None,
++        packed_loss_mask: Optional[Union[List[str], str]] = None,
+     ) -> Union[Dict, Iterator[Dict]]:
+         """
+         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
+@@ -270,6 +273,8 @@ class Engine(EngineBase):
+             data_parallel_rank=data_parallel_rank,
+             external_trace_header=external_trace_header,
+             rid=rid,
++            spec_training_data_id=spec_training_data_id,
++            packed_loss_mask=packed_loss_mask,
+         )
+         generator = self.tokenizer_manager.generate_request(obj, None)
+ 
+@@ -320,6 +325,9 @@ class Engine(EngineBase):
+         data_parallel_rank: Optional[int] = None,
+         external_trace_header: Optional[Dict] = None,
+         rid: Optional[Union[List[str], str]] = None,
++        # Speculative training fields
++        spec_training_data_id: Optional[Union[List[str], str]] = None,
++        packed_loss_mask: Optional[Union[List[str], str]] = None,
+     ) -> Union[Dict, AsyncIterator[Dict]]:
+         """
+         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
+@@ -358,6 +366,8 @@ class Engine(EngineBase):
+             data_parallel_rank=data_parallel_rank,
+             external_trace_header=external_trace_header,
+             rid=rid,
++            spec_training_data_id=spec_training_data_id,
++            packed_loss_mask=packed_loss_mask,
+         )
+         generator = self.tokenizer_manager.generate_request(obj, None)
+ 
+diff --git a/python/sglang/srt/entrypoints/http_server.py b/python/sglang/srt/entrypoints/http_server.py
+index 0bcbd4a37..98348747b 100644
+--- a/python/sglang/srt/entrypoints/http_server.py
++++ b/python/sglang/srt/entrypoints/http_server.py
+@@ -656,6 +656,23 @@ async def generate_request(obj: GenerateReqInput, request: Request):
+             return _create_error_response(e)
+ 
+ 
++@app.api_route("/generate_for_spec_training", methods=["POST", "PUT"])
++async def generate_for_spec_training(obj: GenerateReqInput, request: Request):
++    """Handle a speculative training data collection request.
++
++    This endpoint reuses the generate flow but expects spec_training_data_id
++    and packed_loss_mask to be set.
++    """
++    try:
++        ret = await _global_state.tokenizer_manager.generate_request(
++            obj, request
++        ).__anext__()
++        return ret
++    except ValueError as e:
++        logger.error(f"[http_server] Error: {e}")
++        return _create_error_response(e)
++
++
+ @app.api_route("/encode", methods=["POST", "PUT"])
+ async def encode_request(obj: EmbeddingReqInput, request: Request):
+     """Handle an embedding request."""
+diff --git a/python/sglang/srt/layers/logits_processor.py b/python/sglang/srt/layers/logits_processor.py
+index d0d7c9344..edd537d0b 100644
+--- a/python/sglang/srt/layers/logits_processor.py
++++ b/python/sglang/srt/layers/logits_processor.py
+@@ -104,6 +104,10 @@ class LogitsProcessorOutput:
+     ## Part 5: Customized Info
+     customized_info: Optional[Dict[str, List[Any]]] = None
+ 
++    ## Part 6: Spec training - skip sampling and use these fake token ids
++    skip_sampling_next_token_ids: Optional[torch.Tensor] = None
++    last_hidden_states: Optional[torch.Tensor] = None
++
+ 
+ @dataclasses.dataclass
+ class LogitsMetadata:
+@@ -146,6 +150,12 @@ class LogitsMetadata:
+     # Whether this batch is prefill-only (no token generation needed)
+     is_prefill_only: bool = False
+ 
++    # Whether to return full logits for all tokens during prefill (instead of just last token)
++    return_full_logits: bool = False
++
++    # For spec training
++    has_spec_training: bool = False
++
+     @classmethod
+     def from_forward_batch(cls, forward_batch: ForwardBatch):
+         if (
+@@ -189,6 +199,7 @@ class LogitsMetadata:
+             extend_input_logprob_token_ids_gpu=forward_batch.extend_input_logprob_token_ids_gpu,
+             padded_static_len=forward_batch.padded_static_len,
+             is_prefill_only=forward_batch.is_prefill_only,
++            return_full_logits=forward_batch.return_full_logits,
+             global_num_tokens_gpu=forward_batch.global_num_tokens_gpu,
+             dp_local_start_pos=forward_batch.dp_local_start_pos,
+             dp_local_num_tokens=forward_batch.dp_local_num_tokens,
+@@ -196,6 +207,7 @@ class LogitsMetadata:
+             global_num_tokens_for_logprob_cpu=forward_batch.global_num_tokens_for_logprob_cpu,
+             global_num_tokens_for_logprob_gpu=forward_batch.global_num_tokens_for_logprob_gpu,
+             dp_padding_mode=DpPaddingMode.SUM_LEN,
++            has_spec_training=forward_batch.has_spec_training,
+         )
+ 
+     def compute_dp_attention_metadata(self):
+@@ -303,6 +315,45 @@ class LogitsProcessor(nn.Module):
+         if logits_metadata.forward_mode.is_dllm_extend():
+             return self._get_dllm_logits(hidden_states, lm_head, logits_metadata)
+ 
++        # Return full logits for all tokens during prefill when requested
++        # Can be triggered by either the LogitsProcessor instance flag or LogitsMetadata flag
++        if (
++            self.return_full_logits or logits_metadata.return_full_logits
++        ) and logits_metadata.forward_mode.is_extend():
++            full_logits = self._get_logits(hidden_states, lm_head, logits_metadata)
++            # Also compute the last token logits for sampling
++            if logits_metadata.padded_static_len < 0:
++                last_index = torch.cumsum(logits_metadata.extend_seq_lens, dim=0) - 1
++            else:
++                idx = torch.arange(
++                    len(logits_metadata.extend_seq_lens),
++                    device=logits_metadata.extend_seq_lens.device,
++                )
++                last_index = (
++                    idx * logits_metadata.padded_static_len
++                    + logits_metadata.extend_seq_lens
++                    - 1
++                )
++            sampled_logits = full_logits[last_index]
++            return LogitsProcessorOutput(
++                next_token_logits=sampled_logits,
++                full_logits=full_logits,
++            )
++
++        last_hidden_states = None
++        # Capture last_hidden_states for spec training:
++        # - has_spec_training=True: offline training path
++        # - capture_hidden_mode=FULL in extend/verify: EAGLE3 + spec training path
++        if logits_metadata.has_spec_training or (
++            logits_metadata.capture_hidden_mode == CaptureHiddenMode.FULL
++            and (
++                logits_metadata.forward_mode.is_extend()
++                or logits_metadata.forward_mode.is_target_verify()
++            )
++        ):
++            assert hidden_states_before_norm is None
++            last_hidden_states = hidden_states
++
+         # Get the last hidden states and last logits for the next token prediction
+         (
+             pruned_states,
+@@ -330,6 +381,49 @@ class LogitsProcessor(nn.Module):
+         )
+         del hidden_states
+ 
++        # TODO(ywang): Support finegrained control over requests instead of
++        # forcing all requests to be spec training requests
++
++        # For offline spec training (prefill-only, no decode), skip sampling
++        # and return fake EOS. In decode mode with EAGLE, the eagle_worker
++        # sets has_spec_training=False so this block is not triggered.
++        if (
++            logits_metadata.has_spec_training
++            and logits_metadata.forward_mode.is_extend()
++        ):
++            if logits_metadata.extend_seq_lens is not None:
++                num_seqs = len(logits_metadata.extend_seq_lens)
++            elif input_ids is not None:
++                num_seqs = input_ids.shape[0]
++            else:
++                # Non-head TP rank in multi-node: input_ids not available
++                num_seqs = 1
++            eos_token_id = getattr(self.config, "eos_token_id", 0)
++            if isinstance(eos_token_id, list):
++                eos_token_id = eos_token_id[0]
++            # input_ids can be None on non-head TP ranks in multi-node setup;
++            # last_hidden_states can be a tuple when aux_hidden_states is captured.
++            if input_ids is not None:
++                device = input_ids.device
++            elif isinstance(last_hidden_states, torch.Tensor):
++                device = last_hidden_states.device
++            elif isinstance(last_hidden_states, tuple):
++                device = last_hidden_states[0].device
++            else:
++                device = lm_head.weight.device
++            fake_next_token_ids = torch.full(
++                (num_seqs,),
++                eos_token_id,
++                dtype=torch.long,
++                device=device,
++            )
++            return LogitsProcessorOutput(
++                next_token_logits=None,
++                hidden_states=hidden_states_to_store,
++                last_hidden_states=last_hidden_states,
++                skip_sampling_next_token_ids=fake_next_token_ids,
++            )
++
+         if not logits_metadata.extend_return_logprob:
+             # Compute logits for both input and sampled tokens.
+             logits = self._get_logits(pruned_states, lm_head, logits_metadata)
+@@ -341,6 +435,7 @@ class LogitsProcessor(nn.Module):
+             return LogitsProcessorOutput(
+                 next_token_logits=sampled_logits,
+                 hidden_states=hidden_states_to_store,
++                last_hidden_states=last_hidden_states,
+             )
+ 
+         # Start to process input logprobs
+@@ -381,6 +476,7 @@ class LogitsProcessor(nn.Module):
+         return LogitsProcessorOutput(
+             next_token_logits=sampled_logits,
+             hidden_states=hidden_states_to_store,
++            last_hidden_states=last_hidden_states,
+             input_token_logprobs=logprobs_result.input_token_logprobs,
+             input_top_logprobs_val=logprobs_result.input_top_logprobs_val,
+             input_top_logprobs_idx=logprobs_result.input_top_logprobs_idx,
+@@ -403,6 +499,7 @@ class LogitsProcessor(nn.Module):
+             logits_metadata.forward_mode.is_decode_or_idle()
+             or logits_metadata.forward_mode.is_target_verify()
+             or logits_metadata.forward_mode.is_draft_extend_v2()
++            or logits_metadata.has_spec_training
+         ):
+             pruned_states = hidden_states
+             pruned_states_before_norm = hidden_states_before_norm
+diff --git a/python/sglang/srt/layers/quantization/modelopt_quant.py b/python/sglang/srt/layers/quantization/modelopt_quant.py
+index 7a0dfed08..75a57281d 100755
+--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
++++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
+@@ -1029,25 +1029,34 @@ class ModelOptFp4Config(ModelOptQuantConfig):
+             config.get("packed_modules_mapping"),
+         )
+ 
++    @staticmethod
++    def _normalize_layer_prefix(name: str) -> str:
++        """Normalize a layer prefix by stripping common model hierarchy prefixes.
++
++        Handles mismatches between exclude_modules patterns (from HF quant config)
++        and actual SGLang model prefixes:
++        - Patterns: "language_model.layers.X.self_attn*"
++        - VLM prefix: "language_model.model.layers.X.self_attn.xxx"
++        - Non-VLM prefix: "model.layers.X.self_attn.xxx"
++
++        All normalize to: "layers.X.self_attn..."
++        """
++        for strip_prefix in ["language_model.model.", "language_model.", "model."]:
++            if name.startswith(strip_prefix):
++                return name[len(strip_prefix):]
++        return name
++
+     def is_layer_excluded(self, prefix: str):
+         import regex as re
+ 
+-        fused_patterns = ["q_a_proj", "q_b_proj", "kv_a_proj_with_mqa", "kv_b_proj"]
+-        prefix_split = prefix.split(".")
++        norm_prefix = self._normalize_layer_prefix(prefix)
++
+         for pattern in self.exclude_modules:
+-            regex_str = pattern.replace(".", r"\.").replace("*", r".*")
+-            pattern_split = pattern.split(".")
+-            if re.fullmatch(regex_str, prefix):
+-                return True
+-            elif (
+-                pattern_split[-1] in fused_patterns
+-                and pattern_split[-1] in prefix_split[-1]
+-            ):
+-                # Check if the last part of the excluded pattern is contained in the last part of the prefix
+-                # This handles fused modules like fused_qkv_a_proj_with_mqa that contain q_a_proj and kv_a_proj_with_mqa
+-                # e.g., model.layers.{i}.self_attn.{fused_weight_name}
+-                assert len(prefix_split) == 5 and len(pattern_split) == 5
++            norm_pattern = self._normalize_layer_prefix(pattern)
++            regex_str = norm_pattern.replace(".", r"\.").replace("*", r".*")
++            if re.fullmatch(regex_str, norm_prefix):
+                 return True
++
+         return False
+ 
+     def get_quant_method(self, layer: torch.nn.Module, prefix: str):
+diff --git a/python/sglang/srt/managers/detokenizer_manager.py b/python/sglang/srt/managers/detokenizer_manager.py
+index a65b0dd28..e61c878cb 100644
+--- a/python/sglang/srt/managers/detokenizer_manager.py
++++ b/python/sglang/srt/managers/detokenizer_manager.py
+@@ -403,6 +403,9 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
+             prefill_launch_delay=recv_obj.prefill_launch_delay,
+             prefill_launch_latency=recv_obj.prefill_launch_latency,
+             prefill_finished_ts=recv_obj.prefill_finished_ts,
++            spec_training_data_ids=recv_obj.spec_training_data_ids,
++            packed_loss_masks=recv_obj.packed_loss_masks,
++            spec_training_mooncake_store_keys=recv_obj.spec_training_mooncake_store_keys,
+         )
+ 
+     def handle_multimodal_decode_req(self, recv_obj: BatchMultimodalDecodeReq):
+diff --git a/python/sglang/srt/managers/io_struct.py b/python/sglang/srt/managers/io_struct.py
+index 624812186..4f913eb0f 100644
+--- a/python/sglang/srt/managers/io_struct.py
++++ b/python/sglang/srt/managers/io_struct.py
+@@ -273,6 +273,13 @@ class GenerateReqInput(BaseReq, APIServingTimingMixin):
+     image_max_dynamic_patch: Optional[int] = None
+     video_max_dynamic_patch: Optional[int] = None
+ 
++    # Speculative training fields
++    spec_training_data_id: Optional[Union[List[str], str]] = None
++    packed_loss_mask: Optional[Union[List[str], str]] = None
++
++    def is_spec_training_request(self) -> bool:
++        return self.spec_training_data_id is not None
++
+     def contains_mm_input(self) -> bool:
+         return (
+             has_valid_data(self.image_data)
+@@ -404,6 +411,7 @@ class GenerateReqInput(BaseReq, APIServingTimingMixin):
+         self._normalize_logprob_params(num)
+         self._normalize_custom_logit_processor(num)
+         self._normalize_bootstrap_params(num)
++        self._normalize_spec_training_params(num)
+ 
+     def _expand_inputs(self, num):
+         """Expand the main inputs (text, input_ids, input_embeds) for parallel sampling."""
+@@ -606,6 +614,24 @@ class GenerateReqInput(BaseReq, APIServingTimingMixin):
+         elif isinstance(self.bootstrap_pair_key, list):
+             self.bootstrap_pair_key = self.bootstrap_pair_key * self.parallel_sample_num
+ 
++    def _normalize_spec_training_params(self, num):
++        """Normalize speculative training parameters for batch processing."""
++        if self.spec_training_data_id is None:
++            self.spec_training_data_id = [None] * num
++        elif not isinstance(self.spec_training_data_id, list):
++            self.spec_training_data_id = [self.spec_training_data_id] * num
++        elif isinstance(self.spec_training_data_id, list):
++            self.spec_training_data_id = (
++                self.spec_training_data_id * self.parallel_sample_num
++            )
++
++        if self.packed_loss_mask is None:
++            self.packed_loss_mask = [None] * num
++        elif not isinstance(self.packed_loss_mask, list):
++            self.packed_loss_mask = [self.packed_loss_mask] * num
++        elif isinstance(self.packed_loss_mask, list):
++            self.packed_loss_mask = self.packed_loss_mask * self.parallel_sample_num
++
+     def _validate_session_params(self):
+         """Validate that session parameters are properly formatted."""
+         if self.session_params is not None:
+@@ -678,6 +704,14 @@ class GenerateReqInput(BaseReq, APIServingTimingMixin):
+             return_entropy=self.return_entropy,
+             external_trace_header=self.external_trace_header,
+             http_worker_ipc=self.http_worker_ipc,
++            spec_training_data_id=(
++                self.spec_training_data_id[i]
++                if self.spec_training_data_id is not None
++                else None
++            ),
++            packed_loss_mask=(
++                self.packed_loss_mask[i] if self.packed_loss_mask is not None else None
++            ),
+             **{
+                 field: getattr(self, field)
+                 for field in _API_SERVING_TIMING_MIXIN_FIELDS
+@@ -765,6 +799,10 @@ class TokenizedGenerateReqInput(BaseReq):
+     need_wait_for_image: bool = False
+     num_items_assigned: Optional[List] = None
+ 
++    # Speculative training fields
++    spec_training_data_id: Optional[str] = None
++    packed_loss_mask: Optional[str] = None
++
+ 
+ @dataclass
+ class BatchTokenizedGenerateReqInput(BaseBatchReq):
+@@ -1006,6 +1044,11 @@ class BatchTokenIDOutput(
+     # Customized info
+     customized_info: Optional[Dict[str, List[Any]]] = None
+ 
++    # Speculative training fields
++    spec_training_data_ids: Optional[List[str]] = None
++    packed_loss_masks: Optional[List[str]] = None
++    spec_training_mooncake_store_keys: Optional[List[List[str]]] = None
++
+ 
+ @dataclass
+ class BatchMultimodalDecodeReq(BaseBatchReq):
+@@ -1095,6 +1138,11 @@ class BatchStrOutput(
+     # Customized info
+     customized_info: Optional[Dict[str, List[Any]]] = None
+ 
++    # Speculative training fields
++    spec_training_data_ids: Optional[List[str]] = None
++    packed_loss_masks: Optional[List[str]] = None
++    spec_training_mooncake_store_keys: Optional[List[List[str]]] = None
++
+ 
+ @dataclass
+ class BatchMultimodalOutput(BaseBatchReq):
+@@ -1269,6 +1317,8 @@ class UpdateWeightFromDiskReqInput(BaseReq):
+     token_step: int = 0
+     # Whether to flush the cache after updating weights
+     flush_cache: bool = True
++    # Whether to update draft model instead of target model (for EAGLE speculative decoding)
++    update_draft_model: bool = False
+ 
+ 
+ @dataclass
+diff --git a/python/sglang/srt/managers/schedule_batch.py b/python/sglang/srt/managers/schedule_batch.py
+index 8f3441b1b..f60a43078 100644
+--- a/python/sglang/srt/managers/schedule_batch.py
++++ b/python/sglang/srt/managers/schedule_batch.py
+@@ -46,7 +46,7 @@ from enum import Enum, auto
+ from functools import lru_cache
+ from http import HTTPStatus
+ from itertools import chain
+-from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple, Union
++from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
+ 
+ import numpy as np
+ import torch
+@@ -84,6 +84,7 @@ from sglang.srt.model_executor.forward_batch_info import (
+ from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+ from sglang.srt.sampling.sampling_params import SamplingParams
+ from sglang.srt.server_args import ServerArgs, get_global_server_args
++from sglang.srt.speculative.spec_training_info import SpecTrainingInfo
+ from sglang.srt.utils import flatten_nested_list
+ from sglang.srt.utils.cuda_ipc_transport_utils import CudaIpcTensorTransportProxy
+ 
+@@ -543,6 +544,8 @@ class Req:
+         routing_key: Optional[str] = None,
+         dimensions: Optional[int] = None,
+         http_worker_ipc: Optional[str] = None,
++        spec_training_data_id: Optional[str] = None,
++        packed_loss_mask: Optional[str] = None,
+     ):
+         # Input and output info
+         self.rid = rid
+@@ -583,6 +586,11 @@ class Req:
+         # For multi-http worker
+         self.http_worker_ipc = http_worker_ipc
+ 
++        # Spec training fields
++        self.spec_training_data_id = spec_training_data_id
++        self.packed_loss_mask = packed_loss_mask
++        self.spec_training_mooncake_store_keys: List[str] = []
++
+         # Require reasoning for the request (hybrid reasoning model only)
+         self.require_reasoning = require_reasoning
+ 
+@@ -753,6 +761,8 @@ class Req:
+         # The number of verification forward passes in the speculative decoding.
+         # This is used to compute the average acceptance length per request.
+         self.spec_verify_ct = 0
++        self._spec_decode_hs_chunks = []
++        self._spec_decode_lhs_chunks = []  # For last_hidden_states in spec training
+ 
+         # The number of accepted tokens in speculative decoding for this request.
+         # This is used to compute the acceptance rate and average acceptance length per request.
+@@ -1364,6 +1374,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+     # Metrics
+     dp_cooperation_info: Optional[DPCooperationInfo] = None
+ 
++    # Spec Training
++    spec_training_info: Optional[SpecTrainingInfo] = None
++
+     @classmethod
+     def init_new(
+         cls,
+@@ -1384,6 +1397,15 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+         if isinstance(token_to_kv_pool_allocator, SWATokenToKVPoolAllocator):
+             is_hybrid_swa = True
+ 
++        spec_training_info = SpecTrainingInfo()
++        for req in reqs:
++            if req.spec_training_data_id is not None:
++                spec_training_info.add_request(
++                    rid=req.rid,
++                    data_id=req.spec_training_data_id,
++                    packed_loss_mask=req.packed_loss_mask,
++                )
++
+         return cls(
+             reqs=reqs,
+             req_to_token_pool=req_to_token_pool,
+@@ -1403,6 +1425,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+             chunked_req=chunked_req,
+             dllm_staging_reqs=dllm_staging_reqs,
+             dllm_config=dllm_config,
++            spec_training_info=(
++                spec_training_info if not spec_training_info.is_empty() else None
++            ),
+         )
+ 
+     def batch_size(self):
+@@ -2130,6 +2155,16 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+                 has_been_filtered=has_been_filtered,
+             )
+ 
++        if self.spec_training_info is not None:
++            kept_rids = {req.rid for req in self.reqs}
++            rids_to_remove = [
++                rid for rid in self.spec_training_info.data_ids if rid not in kept_rids
++            ]
++            for rid in rids_to_remove:
++                self.spec_training_info.remove_request(rid)
++            if self.spec_training_info.is_empty():
++                self.spec_training_info = None
++
+     def merge_batch(self, other: "ScheduleBatch"):
+         # NOTE: in spec v2 mode, we do not need wait verify here because
+         # 1) current batch is always prefill, whose seq_lens is not a future
+@@ -2178,6 +2213,23 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+         if self.spec_info:
+             self.spec_info.merge_batch(other.spec_info)
+ 
++        if self.spec_training_info is not None or other.spec_training_info is not None:
++            if self.spec_training_info is None:
++                self.spec_training_info = SpecTrainingInfo()
++            if other.spec_training_info is not None:
++                self.spec_training_info.data_ids.update(
++                    other.spec_training_info.data_ids
++                )
++                self.spec_training_info.prompt_lengths.update(
++                    other.spec_training_info.prompt_lengths
++                )
++                self.spec_training_info.response_lengths.update(
++                    other.spec_training_info.response_lengths
++                )
++                self.spec_training_info.mooncake_store_keys.update(
++                    other.spec_training_info.mooncake_store_keys
++                )
++
+     def get_model_worker_batch(
+         self, seq_lens_cpu_cache: Optional[torch.Tensor] = None
+     ) -> ModelWorkerBatch:
+@@ -2234,7 +2286,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+             hicache_consumer_index=self.hicache_consumer_index,
+             capture_hidden_mode=(
+                 CaptureHiddenMode.FULL
+-                if self.return_hidden_states
++                if self.return_hidden_states or self.spec_training_info is not None
+                 else (
+                     getattr(
+                         self.spec_info, "capture_hidden_mode", CaptureHiddenMode.NULL
+@@ -2253,6 +2305,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+             mamba_track_indices=self.mamba_track_indices,
+             mamba_track_mask=self.mamba_track_mask,
+             mamba_track_seqlens=self.mamba_track_seqlens,
++            has_spec_training=self.spec_training_info is not None,
+         )
+ 
+     def copy(self):
+@@ -2278,6 +2331,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+             mamba_track_mask=self.mamba_track_mask,
+             mamba_track_seqlens=self.mamba_track_seqlens,
+             dp_cooperation_info=self.dp_cooperation_info,
++            spec_training_info=self.spec_training_info,
+         )
+ 
+     def maybe_evict_swa(self):
+@@ -2431,3 +2485,6 @@ class ModelWorkerBatch:
+     mamba_track_indices: Optional[torch.Tensor] = None  # shape: [b], int64
+     mamba_track_mask: Optional[torch.Tensor] = None  # shape: [b], bool
+     mamba_track_seqlens: Optional[torch.Tensor] = None  # shape: [b], int64
++
++    # For spec training
++    has_spec_training: bool = False
+diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
+index e818deaa4..14cdfd90b 100644
+--- a/python/sglang/srt/managers/scheduler.py
++++ b/python/sglang/srt/managers/scheduler.py
+@@ -346,6 +346,26 @@ class Scheduler(
+         # Init moe config and GEMM config (FP8 GEMM, etc.)
+         self.init_moe_gemm_config()
+ 
++        # Start mooncake store init in background (overlaps with model loading)
++        self._mooncake_init_thread = None
++        self._mooncake_init_error = None
++        self.eagle_mooncake_store = None
++        if self.server_args.enable_spec_training_mooncake and self.attn_tp_rank == 0:
++            import threading
++
++            mooncake_device = torch.device(f"cuda:{self.gpu_id}")
++
++            def _init_mooncake():
++                try:
++                    self.init_eagle_mooncake_store(device=mooncake_device)
++                except Exception as e:
++                    self._mooncake_init_error = e
++
++            self._mooncake_init_thread = threading.Thread(
++                target=_init_mooncake, daemon=True
++            )
++            self._mooncake_init_thread.start()
++
+         # Launch a model worker and draft model worker if using speculative decoding
+         self.init_model_worker()
+ 
+@@ -394,6 +414,12 @@ class Scheduler(
+         # Init the grammar backend for constrained generation
+         self.grammar_manager = GrammarManager(self)
+ 
++        # Wait for background mooncake store init to complete
++        if self._mooncake_init_thread is not None:
++            self._mooncake_init_thread.join()
++            if self._mooncake_init_error is not None:
++                raise self._mooncake_init_error
++
+         self.is_initializing = False
+ 
+     def init_model_config(self):
+@@ -727,6 +753,28 @@ class Scheduler(
+         self.forward_sleep_time = None
+         self._engine_paused = False
+ 
++    def init_eagle_mooncake_store(self, device=None):
++        # Per-request GPU storage for decode hidden state accumulation
++        self._decode_hs_storage = {}
++        self._decode_lhs_storage = {}
++        if self.server_args.enable_spec_training_mooncake:
++            try:
++                from torchspec.transfer.mooncake import (
++                    EagleMooncakeStore,
++                    MooncakeConfig,
++                )
++
++                config = MooncakeConfig.from_env()
++                store = EagleMooncakeStore(config)
++                store.setup(device=device or self.device)
++                store.warmup_rdma()
++                self.eagle_mooncake_store = store
++                logger.info("EagleMooncakeStore initialized for spec training")
++            except ImportError:
++                logger.warning(
++                    "torchspec.mooncake not found. Spec training mooncake store disabled."
++                )
++
+     def init_chunked_prefill(self):
+         # Init chunked prefill
+         self.chunked_prefill_size = self.server_args.chunked_prefill_size
+@@ -1468,6 +1516,8 @@ class Scheduler(
+                 routing_key=recv_req.routing_key,
+                 http_worker_ipc=recv_req.http_worker_ipc,
+                 dllm_config=self.dllm_config,
++                spec_training_data_id=recv_req.spec_training_data_id,
++                packed_loss_mask=recv_req.packed_loss_mask,
+             )
+             req.tokenizer = self.tokenizer
+ 
+@@ -2276,7 +2326,10 @@ class Scheduler(
+                     batch_result.copy_done = self.device_module.Event()
+                     if batch_result.delay_sample_func is None:
+                         self.future_map.store_to_map(future_indices, batch_result)
+-                        batch_result.copy_to_cpu(return_logprob=batch.return_logprob)
++                        batch_result.copy_to_cpu(
++                            return_logprob=batch.return_logprob,
++                            skip_hidden_states=batch.spec_training_info is not None,
++                        )
+                     else:
+                         batch_result.future_indices = future_indices
+ 
+@@ -2385,7 +2438,10 @@ class Scheduler(
+             _batch_result = batch_result.delay_sample_func()
+             assert _batch_result is batch_result
+             self.future_map.store_to_map(batch_result.future_indices, batch_result)
+-            batch_result.copy_to_cpu(return_logprob=self.cur_batch.return_logprob)
++            batch_result.copy_to_cpu(
++                return_logprob=self.cur_batch.return_logprob,
++                skip_hidden_states=self.cur_batch.spec_training_info is not None,
++            )
+ 
+     def process_batch_result(
+         self,
+diff --git a/python/sglang/srt/managers/scheduler_output_processor_mixin.py b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+index d79f929d3..45c17b76b 100644
+--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
++++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+@@ -180,21 +180,22 @@ class SchedulerOutputProcessorMixin:
+                             )
+                         logprob_pt += num_input_logprobs
+ 
+-                    if (
+-                        req.return_hidden_states
+-                        and logits_output.hidden_states is not None
+-                    ):
+-                        req.hidden_states.append(
+-                            logits_output.hidden_states[
+-                                hidden_state_offset : (
+-                                    hidden_state_offset := hidden_state_offset
+-                                    + len(req.origin_input_ids)
+-                                )
+-                            ]
+-                            .cpu()
+-                            .clone()
+-                            .tolist()
++                    should_process_hidden_states = (
++                        logits_output.hidden_states is not None
++                        and (
++                            req.return_hidden_states
++                            or (
++                                req.spec_training_data_id is not None
++                                and self.attn_tp_rank == 0
++                            )
+                         )
++                    )
++                    if should_process_hidden_states:
++                        self._process_hidden_states_for_req(
++                            req, batch, logits_output, hidden_state_offset,
++                            copy_done_event=result.copy_done,
++                        )
++                        hidden_state_offset += len(req.origin_input_ids)
+ 
+                     if req.grammar is not None:
+                         # FIXME: this try-except block is for handling unexpected xgrammar issue.
+@@ -426,6 +427,53 @@ class SchedulerOutputProcessorMixin:
+         if (timeout_ms := envs.SGLANG_FORWARD_TIMEOUT_MS.get()) > 0:
+             deadline = time.perf_counter() - timeout_ms / 1000.0
+ 
++        if hasattr(self, "_decode_hs_storage") and self.attn_tp_rank == 0:
++            if not batch.spec_algorithm.is_none():
++                # Speculative decoding: hidden states were captured per-request in verify()
++                for req in batch.reqs:
++                    if (
++                        hasattr(req, "_spec_decode_hs_chunks")
++                        and req._spec_decode_hs_chunks
++                    ):
++                        if req.rid in self._decode_hs_storage:
++                            self._decode_hs_storage[req.rid].extend(
++                                req._spec_decode_hs_chunks
++                            )
++                            req._spec_decode_hs_chunks.clear()
++                    # Also collect last_hidden_states for spec training
++                    if (
++                        hasattr(req, "_spec_decode_lhs_chunks")
++                        and req._spec_decode_lhs_chunks
++                    ):
++                        if req.rid in self._decode_lhs_storage:
++                            self._decode_lhs_storage[req.rid].extend(
++                                req._spec_decode_lhs_chunks
++                            )
++                            req._spec_decode_lhs_chunks.clear()
++            elif logits_output.hidden_states is not None:
++                for i, req in enumerate(batch.reqs):
++                    if req.rid in self._decode_hs_storage:
++                        if logits_output.hidden_states.dim() == 2:
++                            hs = logits_output.hidden_states[i : i + 1].clone()
++                        else:
++                            hs = logits_output.hidden_states[i].unsqueeze(0).clone()
++                        self._decode_hs_storage[req.rid].append(hs)
++                        if (
++                            logits_output.last_hidden_states is not None
++                            and req.rid in self._decode_lhs_storage
++                        ):
++                            if logits_output.last_hidden_states.dim() == 2:
++                                lhs = logits_output.last_hidden_states[
++                                    i : i + 1
++                                ].clone()
++                            else:
++                                lhs = (
++                                    logits_output.last_hidden_states[i]
++                                    .unsqueeze(0)
++                                    .clone()
++                                )
++                            self._decode_lhs_storage[req.rid].append(lhs)
++
+         # Check finish condition
+         for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
+             req: Req
+@@ -456,6 +504,14 @@ class SchedulerOutputProcessorMixin:
+             req.check_finished(new_accepted_len)
+ 
+             if req.finished():
++                # Store accumulated hidden states to Mooncake before cleanup (TP0 only)
++                if (
++                    hasattr(self, "_decode_hs_storage")
++                    and self.attn_tp_rank == 0
++                    and req.rid in self._decode_hs_storage
++                ):
++                    self._flush_decode_hs_to_mooncake(req, batch)
++
+                 self.maybe_collect_routed_experts(req)
+ 
+                 if self.server_args.disaggregation_decode_enable_offload_kvcache:
+@@ -843,6 +899,162 @@ class SchedulerOutputProcessorMixin:
+         if req.input_token_ids_logprobs_idx is None:
+             req.input_token_ids_logprobs_idx = []
+ 
++    def _process_hidden_states_for_req(
++        self: Scheduler,
++        req: Req,
++        batch: ScheduleBatch,
++        logits_output: LogitsProcessorOutput,
++        hidden_state_offset: int,
++        copy_done_event=None,
++    ):
++        """Process hidden states during prefill.
++
++        For spec training requests with Mooncake in decode mode: accumulate on GPU.
++        Storage happens when the request finishes (after decode completes).
++        For prefill-only mode: send directly to Mooncake.
++        """
++        seq_len = len(req.origin_input_ids)
++        req_hidden_states = logits_output.hidden_states[
++            hidden_state_offset : hidden_state_offset + seq_len
++        ]
++
++        if (
++            batch.spec_training_info is not None
++            and batch.spec_training_info.has_request(req.rid)
++            and self.eagle_mooncake_store is not None
++        ):
++            if req.sampling_params.max_new_tokens > 0:
++                # Decode mode: accumulate on GPU for later Mooncake storage
++                # (flushed when request finishes in process_batch_result_decode)
++                if req.rid not in self._decode_hs_storage:
++                    self._decode_hs_storage[req.rid] = []
++                    self._decode_lhs_storage[req.rid] = []
++                self._decode_hs_storage[req.rid].append(req_hidden_states.clone())
++                if logits_output.last_hidden_states is not None:
++                    lhs = logits_output.last_hidden_states[
++                        hidden_state_offset : hidden_state_offset + seq_len
++                    ]
++                    self._decode_lhs_storage[req.rid].append(lhs.clone())
++            else:
++                # Prefill-only mode: send directly to Mooncake (no decode step follows)
++                self._send_hidden_states_to_mooncake(
++                    req, batch, req_hidden_states, logits_output, hidden_state_offset,
++                    copy_done_event=copy_done_event,
++                )
++        else:
++            req.hidden_states.append(req_hidden_states.cpu().clone().tolist())
++
++    def _send_hidden_states_to_mooncake(
++        self: Scheduler,
++        req: Req,
++        batch: ScheduleBatch,
++        hidden_states: torch.Tensor,
++        logits_output: LogitsProcessorOutput,
++        hidden_state_offset: int,
++        copy_done_event=None,
++    ):
++        # TODO(ywang): Do not send input_ids and loss_mask. Training can reconstruct them.
++        import uuid
++
++        data_id = batch.spec_training_info.data_ids.get(req.rid, req.rid)
++        key = f"{data_id}_{uuid.uuid4().hex[:8]}"
++
++        seq_len = hidden_states.shape[0]
++        input_ids = torch.tensor(
++            req.origin_input_ids, dtype=torch.long, device=hidden_states.device
++        )
++
++        last_hidden_states = None
++        if logits_output.last_hidden_states is not None:
++            last_hidden_states = logits_output.last_hidden_states[
++                hidden_state_offset : hidden_state_offset + seq_len
++            ]
++
++        if hidden_states.is_cuda and copy_done_event is not None:
++            torch.cuda.current_stream().wait_event(copy_done_event)
++
++        self.eagle_mooncake_store.put(
++            key=key,
++            hidden_states=hidden_states,
++            input_ids=input_ids,
++            last_hidden_states=last_hidden_states,
++        )
++
++        req.spec_training_mooncake_store_keys.append(key)
++        batch.spec_training_info.mooncake_store_keys[data_id].append(key)
++
++    def _flush_decode_hs_to_mooncake(
++        self: Scheduler,
++        req: Req,
++        batch: ScheduleBatch,
++    ):
++        """Concatenate accumulated hidden states and store to Mooncake.
++
++        Called when a spec training request finishes after full decode.
++        Stores hidden states for the entire prompt+output sequence.
++        """
++        import uuid as uuid_mod
++
++        chunks = self._decode_hs_storage.pop(req.rid, [])
++        lhs_chunks = self._decode_lhs_storage.pop(req.rid, [])
++
++        if not chunks:
++            return
++
++        all_hidden_states = torch.cat(chunks, dim=0)
++        del chunks
++
++        all_last_hidden_states = None
++        if lhs_chunks:
++            all_last_hidden_states = torch.cat(lhs_chunks, dim=0)
++            del lhs_chunks
++
++        # Build input_ids for the full sequence (prompt + output)
++        full_ids = list(req.origin_input_ids) + list(req.output_ids)
++        seq_len = all_hidden_states.shape[0]
++        full_ids = full_ids[:seq_len]
++        input_ids = torch.tensor(
++            full_ids, dtype=torch.long, device=all_hidden_states.device
++        )
++
++        # Get data_id
++        data_id = req.rid
++        if (
++            batch.spec_training_info is not None
++            and batch.spec_training_info.has_request(req.rid)
++        ):
++            data_id = batch.spec_training_info.data_ids.get(req.rid, req.rid)
++
++        key = f"{data_id}_{uuid_mod.uuid4().hex[:8]}"
++
++        # For decoding sometimes we miss the last token hidden states
++        all_hidden_states = all_hidden_states[
++            : len(req.origin_input_ids) + len(req.output_ids) - 1
++        ]
++        all_last_hidden_states = all_last_hidden_states[
++            : len(req.origin_input_ids) + len(req.output_ids) - 1
++        ]
++        input_ids = input_ids[: len(req.origin_input_ids) + len(req.output_ids) - 1]
++        logger.debug(
++            f"[DECODE_HS] Storing to Mooncake: key={key}, "
++            f"hs={tuple(all_hidden_states.shape)}, ids={tuple(input_ids.shape)}, "
++            f"lhs={tuple(all_last_hidden_states.shape) if all_last_hidden_states is not None else None}, "
++            f"prompt={len(req.origin_input_ids)}, output={len(req.output_ids)}"
++        )
++        self.eagle_mooncake_store.put(
++            key=key,
++            hidden_states=all_hidden_states,
++            input_ids=input_ids,
++            last_hidden_states=all_last_hidden_states,
++        )
++
++        req.spec_training_mooncake_store_keys.append(key)
++        if (
++            batch.spec_training_info is not None
++            and data_id in batch.spec_training_info.mooncake_store_keys
++        ):
++            batch.spec_training_info.mooncake_store_keys[data_id].append(key)
++
+     def stream_output(
+         self: Scheduler,
+         reqs: List[Req],
+@@ -901,6 +1113,18 @@ class SchedulerOutputProcessorMixin:
+         routed_experts = None
+         customized_info = {}
+ 
++        if self.attn_tp_rank == 0 and self.eagle_mooncake_store is not None:
++            self.eagle_mooncake_store.flush()
++
++        if self.attn_tp_rank == 0:
++            spec_training_data_ids = []
++            packed_loss_masks = []
++            spec_training_mooncake_store_keys = []
++        else:
++            spec_training_data_ids = None
++            packed_loss_masks = None
++            spec_training_mooncake_store_keys = None
++
+         queue_times = []
+         forward_entry_times = []
+         prefill_launch_delays = []
+@@ -1022,6 +1246,13 @@ class SchedulerOutputProcessorMixin:
+                     spec_verify_ct.append(req.spec_verify_ct)
+                     spec_accepted_tokens.append(req.spec_accepted_tokens)
+ 
++                if spec_training_data_ids is not None:
++                    spec_training_data_ids.append(req.spec_training_data_id)
++                    packed_loss_masks.append(req.packed_loss_mask)
++                    spec_training_mooncake_store_keys.append(
++                        req.spec_training_mooncake_store_keys
++                    )
++
+                 if return_logprob:
+                     if (
+                         req.return_logprob
+@@ -1091,9 +1322,15 @@ class SchedulerOutputProcessorMixin:
+                         output_token_ids_logprobs_idx.append([])
+ 
+                 if req.return_hidden_states:
+-                    if output_hidden_states is None:
+-                        output_hidden_states = []
+-                    output_hidden_states.append(req.hidden_states)
++                    uses_mooncake = (
++                        self.attn_tp_rank == 0
++                        and req.spec_training_data_id is not None
++                        and self.eagle_mooncake_store is not None
++                    )
++                    if not uses_mooncake:
++                        if output_hidden_states is None:
++                            output_hidden_states = []
++                        output_hidden_states.append(req.hidden_states)
+                 if req.return_routed_experts:
+                     if routed_experts is None:
+                         routed_experts = []
+@@ -1158,6 +1395,15 @@ class SchedulerOutputProcessorMixin:
+                     placeholder_tokens_val=None,
+                     retraction_counts=retraction_counts,
+                     load=load,
++                    spec_training_data_ids=(
++                        spec_training_data_ids if spec_training_data_ids else None
++                    ),
++                    packed_loss_masks=packed_loss_masks if packed_loss_masks else None,
++                    spec_training_mooncake_store_keys=(
++                        spec_training_mooncake_store_keys
++                        if spec_training_mooncake_store_keys
++                        else None
++                    ),
+                 )
+             )
+ 
+diff --git a/python/sglang/srt/managers/scheduler_update_weights_mixin.py b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+index 293a84350..6f34eb665 100644
+--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
++++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+@@ -13,6 +13,7 @@ from sglang.srt.constants import (
+     GPU_MEMORY_TYPE_WEIGHTS,
+ )
+ from sglang.srt.managers.io_struct import (
++    AbortReq,
+     CheckWeightsReqInput,
+     CheckWeightsReqOutput,
+     DestroyWeightsUpdateGroupReqInput,
+@@ -47,7 +48,24 @@ class SchedulerUpdateWeightsMixin:
+         self: Scheduler, recv_req: UpdateWeightFromDiskReqInput
+     ):
+         """In-place update of the weights from disk."""
+-        success, message = self.tp_worker.update_weights_from_disk(recv_req)
++        if recv_req.abort_all_requests:
++            logger.info("Aborting all waiting requests before weight update")
++            self.abort_request(AbortReq(rid="", abort_all=True))
++
++        # Check if we should update draft model instead of target model
++        if recv_req.update_draft_model:
++            if not hasattr(self, "draft_worker") or self.draft_worker is None:
++                success = False
++                message = "No draft worker available. Server is not running speculative decoding."
++                logger.error(message)
++                return UpdateWeightFromDiskReqOutput(success, message, 0)
++
++            logger.info(f"Updating draft model weights from {recv_req.model_path}")
++            success, message = self.draft_worker.update_weights_from_disk(recv_req)
++        else:
++            logger.info(f"Updating target model weights from {recv_req.model_path}")
++            success, message = self.tp_worker.update_weights_from_disk(recv_req)
++
+         if success:
+             if recv_req.flush_cache:
+                 flush_cache_success = self.flush_cache()
+diff --git a/python/sglang/srt/managers/tokenizer_manager.py b/python/sglang/srt/managers/tokenizer_manager.py
+index 69806de1d..411752d0b 100644
+--- a/python/sglang/srt/managers/tokenizer_manager.py
++++ b/python/sglang/srt/managers/tokenizer_manager.py
+@@ -945,6 +945,8 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
+                 routing_key=obj.routing_key,
+                 need_wait_for_image=obj.need_wait_for_image,
+                 num_items_assigned=obj.num_items_assigned,
++                spec_training_data_id=obj.spec_training_data_id,
++                packed_loss_mask=obj.packed_loss_mask,
+             )
+         elif isinstance(obj, EmbeddingReqInput):
+             tokenized_obj = TokenizedEmbeddingReqInput(
+@@ -1595,6 +1597,20 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
+                 if self.enable_metrics:
+                     self._calculate_timing_metrics(meta_info, state, recv_obj, i)
+ 
++                if (
++                    hasattr(recv_obj, "spec_training_data_ids")
++                    and recv_obj.spec_training_data_ids is not None
++                    and i < len(recv_obj.spec_training_data_ids)
++                    and recv_obj.spec_training_data_ids[i] is not None
++                ):
++                    meta_info["spec_training_data_id"] = (
++                        recv_obj.spec_training_data_ids[i]
++                    )
++                    meta_info["packed_loss_mask"] = recv_obj.packed_loss_masks[i]
++                    meta_info["spec_training_mooncake_store_keys"] = (
++                        recv_obj.spec_training_mooncake_store_keys[i]
++                    )
++
+                 trace_req_finish(
+                     rid,
+                     ts=int(state.finished_time * 1e9),
+diff --git a/python/sglang/srt/managers/utils.py b/python/sglang/srt/managers/utils.py
+index 9eea302b7..66f5cab33 100644
+--- a/python/sglang/srt/managers/utils.py
++++ b/python/sglang/srt/managers/utils.py
+@@ -49,7 +49,7 @@ class GenerationBatchResult:
+     # metrics
+     expert_distribution_metrics: Optional[ExpertDistributionMetrics] = None
+ 
+-    def copy_to_cpu(self, return_logprob: bool):
++    def copy_to_cpu(self, return_logprob: bool, skip_hidden_states: bool = False):
+         """Copy tensors to CPU in overlap scheduling.
+         Only the tensors which are needed for processing results are copied,
+         e.g., next_token_ids, logits outputs
+@@ -63,7 +63,8 @@ class GenerationBatchResult:
+                 self.logits_output.input_token_logprobs = (
+                     self.logits_output.input_token_logprobs.to("cpu", non_blocking=True)
+                 )
+-        if self.logits_output.hidden_states is not None:
++        # When overlap is enabled, hidden_states stay on GPU for _copy_stream DtoH in put().
++        if self.logits_output.hidden_states is not None and not skip_hidden_states:
+             self.logits_output.hidden_states = self.logits_output.hidden_states.to(
+                 "cpu", non_blocking=True
+             )
+diff --git a/python/sglang/srt/model_executor/cuda_graph_runner.py b/python/sglang/srt/model_executor/cuda_graph_runner.py
+index b0b2ede6d..3d15d2b67 100644
+--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
++++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
+@@ -878,6 +878,11 @@ class CudaGraphRunner:
+                     if output.hidden_states is not None
+                     else None
+                 ),
++                last_hidden_states=(
++                    output.last_hidden_states[: self.raw_num_token]
++                    if output.last_hidden_states is not None
++                    else None
++                ),
+                 customized_info=output.customized_info,
+             )
+         else:
+diff --git a/python/sglang/srt/model_executor/forward_batch_info.py b/python/sglang/srt/model_executor/forward_batch_info.py
+index bcd1fda10..8b921d214 100644
+--- a/python/sglang/srt/model_executor/forward_batch_info.py
++++ b/python/sglang/srt/model_executor/forward_batch_info.py
+@@ -270,6 +270,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
+     return_logprob: bool = False
+     top_logprobs_nums: Optional[List[int]] = None
+     token_ids_logprobs: Optional[List[List[int]]] = None
++    # Return full logits for all tokens during prefill (instead of just last token)
++    return_full_logits: bool = False
+ 
+     # For logits and logprobs post processing
+     next_token_logits_buffer: torch.Tensor = None
+@@ -375,6 +377,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
+     # For hidden states before normal
+     return_hidden_states_before_norm: bool = False
+ 
++    # For spec training
++    has_spec_training: bool = False
++
+     @classmethod
+     def init_new(
+         cls,
+@@ -419,6 +424,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
+             tbo_split_seq_index=batch.tbo_split_seq_index,
+             dimensions=batch.dimensions,
+             return_hidden_states_before_norm=batch.return_hidden_states_before_norm,
++            has_spec_training=batch.has_spec_training,
+         )
+         device = model_runner.device
+ 
+diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
+index 01d6c8866..d0ff3eb8d 100644
+--- a/python/sglang/srt/model_executor/model_runner.py
++++ b/python/sglang/srt/model_executor/model_runner.py
+@@ -323,6 +323,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+         self.remote_instance_transfer_engine_weight_info = None
+         # auxiliary hidden capture mode. TODO: expose this to server args?
+         self.eagle_use_aux_hidden_state = False
++        self.eagle_aux_hidden_state_layer_ids = None
+         if self.spec_algorithm.is_eagle3() and not self.is_draft_worker:
+             # load draft config
+             draft_model_config = ModelConfig.from_server_args(
+@@ -348,6 +349,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+                 # if there is no aux layer, set to None
+                 self.eagle_aux_hidden_state_layer_ids = None
+ 
++        if self.server_args.enable_aux_hidden_states:
++            self.eagle_use_aux_hidden_state = True
++            if self.server_args.aux_hidden_state_layer_ids is not None:
++                self.eagle_aux_hidden_state_layer_ids = (
++                    self.server_args.aux_hidden_state_layer_ids
++                )
++
+         # Apply the rank zero filter to logger
+         if server_args.show_time_cost:
+             enable_show_time_cost()
+@@ -596,6 +604,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+             register_forward_hooks(self.model, server_args.forward_hooks)
+ 
+         if self.eagle_use_aux_hidden_state:
++            if not hasattr(self.model, "set_eagle3_layers_to_capture"):
++                raise RuntimeError(
++                    "Aux hidden state capture is not supported by this model."
++                )
+             self.model.set_eagle3_layers_to_capture(
+                 self.eagle_aux_hidden_state_layer_ids
+             )
+@@ -2421,6 +2433,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+                 axis=-1,
+             )
+ 
++        # Spec training: skip sampling and return fake EOS tokens
++        if logits_output.skip_sampling_next_token_ids is not None:
++            return logits_output.skip_sampling_next_token_ids
++
+         self._preprocess_logits(logits_output, forward_batch.sampling_info)
+         # Sample the next tokens
+         next_token_ids = self.sampler(
+diff --git a/python/sglang/srt/models/kimi_k25.py b/python/sglang/srt/models/kimi_k25.py
+index 048ef0578..e7a85ce81 100644
+--- a/python/sglang/srt/models/kimi_k25.py
++++ b/python/sglang/srt/models/kimi_k25.py
+@@ -740,5 +740,22 @@ class KimiK25ForConditionalGeneration(nn.Module):
+         if language_weights:
+             self.language_model.load_weights(language_weights)
+ 
++    def get_embed_and_head(self):
++        return self.language_model.model.embed_tokens.weight, self.language_model.lm_head.weight
++
++    def set_eagle3_layers_to_capture(self, layer_ids: Optional[List[int]] = None):
++        self.capture_aux_hidden_states = True
++        self.language_model.capture_aux_hidden_states = True
++        self.language_model.model.capture_aux_hidden_states = True
++        if layer_ids is None:
++            num_layers = self.config.text_config.num_hidden_layers
++            self.language_model.model.layers_to_capture = [
++                2,
++                num_layers // 2,
++                num_layers - 3,
++            ]
++        else:
++            self.language_model.model.layers_to_capture = [val + 1 for val in layer_ids]
++
+ 
+ EntryClass = [KimiK25ForConditionalGeneration]
+diff --git a/python/sglang/srt/models/qwen3_next.py b/python/sglang/srt/models/qwen3_next.py
+index 9e96797c0..2d2a2cadb 100644
+--- a/python/sglang/srt/models/qwen3_next.py
++++ b/python/sglang/srt/models/qwen3_next.py
+@@ -1,6 +1,6 @@
+ import enum
+ import logging
+-from typing import Any, Iterable, Optional, Set, Tuple
++from typing import Any, Iterable, List, Optional, Set, Tuple
+ 
+ import torch
+ from torch import nn
+@@ -843,6 +843,12 @@ class Qwen3NextModel(nn.Module):
+ 
+         self.norm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+         self.infer_count = 0
++        self.layers_to_capture = []
++
++    def set_eagle3_layers_to_capture(self, layers_to_capture: List[int]):
++        self.layers_to_capture = layers_to_capture
++        for layer_id in self.layers_to_capture:
++            setattr(self.layers[layer_id], "_is_layer_to_capture", True)
+ 
+     def forward(
+         self,
+@@ -862,7 +868,12 @@ class Qwen3NextModel(nn.Module):
+             hidden_states = self.embed_tokens(input_ids)
+ 
+         residual = None
++        aux_hidden_states = []
+         for i in range(len(self.layers)):
++            if i in self.layers_to_capture:
++                aux_hidden_states.append(
++                    hidden_states + residual if residual is not None else hidden_states
++                )
+             layer = self.layers[i]
+             with get_global_expert_distribution_recorder().with_current_layer(i):
+                 hidden_states, residual = layer(
+@@ -879,7 +890,10 @@ class Qwen3NextModel(nn.Module):
+             else:
+                 hidden_states, _ = self.norm(hidden_states, residual)
+ 
+-        return hidden_states
++        if len(aux_hidden_states) == 0:
++            return hidden_states
++
++        return hidden_states, aux_hidden_states
+ 
+ 
+ class HybridLayerType(enum.Enum):
+@@ -924,6 +938,9 @@ class Qwen3NextForCausalLM(nn.Module):
+             }
+         )
+ 
++        self.capture_aux_hidden_states = False
++        self.hot_token_id = None
++
+     @property
+     def routed_experts_weights_of_layer(self):
+         return self._routed_experts_weights_of_layer.value
+@@ -939,8 +956,12 @@ class Qwen3NextForCausalLM(nn.Module):
+     ):
+         hidden_states = self.model(input_ids, positions, forward_batch, inputs_embeds)
+ 
++        aux_hidden_states = None
++        if self.capture_aux_hidden_states:
++            hidden_states, aux_hidden_states = hidden_states
++
+         return self.logits_processor(
+-            input_ids, hidden_states, self.lm_head, forward_batch
++            input_ids, hidden_states, self.lm_head, forward_batch, aux_hidden_states
+         )
+ 
+     def get_embed_and_head(self):
+@@ -954,6 +975,37 @@ class Qwen3NextForCausalLM(nn.Module):
+         torch.cuda.empty_cache()
+         torch.cuda.synchronize()
+ 
++    def get_embed(self):
++        return self.model.embed_tokens.weight
++
++    def set_embed(self, embed):
++        if (
++            hasattr(self.config, "target_hidden_size")
++            and self.config.target_hidden_size != self.config.hidden_size
++        ):
++            return
++        del self.model.embed_tokens.weight
++        self.model.embed_tokens.weight = embed
++        torch.cuda.empty_cache()
++        torch.cuda.synchronize()
++
++    def set_eagle3_layers_to_capture(self, layer_ids: Optional[List[int]] = None):
++        if not self.pp_group.is_last_rank:
++            return
++
++        self.capture_aux_hidden_states = True
++        if layer_ids is None:
++            num_layers = self.config.num_hidden_layers
++            self.model.set_eagle3_layers_to_capture(
++                [
++                    2,
++                    num_layers // 2,
++                    num_layers - 3,
++                ]
++            )  # Specific layers for EAGLE3 support
++        else:
++            self.model.set_eagle3_layers_to_capture([val + 1 for val in layer_ids])
++
+     def load_weights(
+         self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False
+     ) -> Set[str]:
+@@ -979,6 +1031,13 @@ class Qwen3NextForCausalLM(nn.Module):
+         loaded_params: Set[str] = set()
+         for name, loaded_weight in weights:
+ 
++            if "d2t" in name:
++                self.hot_token_id = loaded_weight + torch.arange(loaded_weight.shape[0])
++                continue
++
++            if "t2d" in name:
++                continue
++
+             if is_mtp:
+ 
+                 if "mtp" not in name:
+diff --git a/python/sglang/srt/models/qwen3_next_mtp.py b/python/sglang/srt/models/qwen3_next_mtp.py
+index aa0f8ec1e..2f8521c6a 100644
+--- a/python/sglang/srt/models/qwen3_next_mtp.py
++++ b/python/sglang/srt/models/qwen3_next_mtp.py
+@@ -72,6 +72,9 @@ class Qwen3NextForCausalLMMTP(Qwen3NextForCausalLM):
+         )
+         self.logits_processor = LogitsProcessor(config)
+ 
++        self.capture_aux_hidden_states = False
++        self.hot_token_id = None
++
+     @torch.no_grad()
+     def forward(
+         self,
+diff --git a/python/sglang/srt/server_args.py b/python/sglang/srt/server_args.py
+index 1c7074715..0cc83b842 100644
+--- a/python/sglang/srt/server_args.py
++++ b/python/sglang/srt/server_args.py
+@@ -483,6 +483,10 @@ class ServerArgs:
+     speculative_ngram_capacity: int = 10 * 1000 * 1000
+     enable_multi_layer_eagle: bool = False
+ 
++    # Spec training (for speculative decoding model training)
++    enable_spec_training_mooncake: bool = False
++    enable_aux_hidden_states: bool = False
++    aux_hidden_state_layer_ids: Optional[List[int]] = None
+     # Expert parallelism
+     ep_size: int = 1
+     moe_a2a_backend: Literal[
+@@ -3928,6 +3932,23 @@ class ServerArgs:
+             help="Enable multi-layer Eagle speculative decoding.",
+         )
+ 
++        # Spec training (for speculative decoding model training)
++        parser.add_argument(
++            "--enable-spec-training-mooncake",
++            action="store_true",
++            help="Enable EagleMooncakeStore for spec training hidden state transfer.",
++        )
++        parser.add_argument(
++            "--enable-aux-hidden-states",
++            action="store_true",
++            help="Enable capturing auxiliary hidden states for supported models.",
++        )
++        parser.add_argument(
++            "--aux-hidden-state-layer-ids",
++            type=int,
++            nargs="+",
++            help="Layer IDs to capture as auxiliary hidden states. If omitted, model defaults are used.",
++        )
+         # Expert parallelism
+         parser.add_argument(
+             "--expert-parallel-size",
+diff --git a/python/sglang/srt/speculative/eagle_info.py b/python/sglang/srt/speculative/eagle_info.py
+index e22eeaee4..1f07955fe 100644
+--- a/python/sglang/srt/speculative/eagle_info.py
++++ b/python/sglang/srt/speculative/eagle_info.py
+@@ -429,6 +429,20 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
+             req.spec_accepted_tokens += (
+                 sum(1 for idx in accept_index_row if idx != -1) - 1
+             )
++            # Capture accepted hidden states per-request for spec training
++            if (
++                batch.spec_info.hidden_states is not None
++                and batch.spec_training_info is not None
++                and batch.spec_training_info.has_request(req.rid)
++            ):
++                req_accepted = [idx for idx in accept_index_row if idx != -1]
++                if req_accepted:
++                    hs = batch.spec_info.hidden_states[req_accepted].clone()
++                    req._spec_decode_hs_chunks.append(hs)
++                    # Also capture last_hidden_states for spec training
++                    if batch.spec_info.last_hidden_states is not None:
++                        lhs = batch.spec_info.last_hidden_states[req_accepted].clone()
++                        req._spec_decode_lhs_chunks.append(lhs)
+ 
+         if has_finished:
+             accept_length = (accept_index != -1).sum(dim=1) - 1
+@@ -660,6 +674,13 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
+             return
+ 
+         # Prefill only generate 1 token.
++        if len(self.verified_id) != len(batch.seq_lens):
++            logger.error(
++                f"prepare_for_extend mismatch: verified_id={self.verified_id.shape}, "
++                f"seq_lens={batch.seq_lens.shape}, forward_mode={batch.forward_mode}, "
++                f"spec_training_info={batch.spec_training_info is not None}, "
++                f"return_hidden_states={batch.return_hidden_states}"
++            )
+         assert len(self.verified_id) == len(batch.seq_lens)
+ 
+         pt = 0
+diff --git a/python/sglang/srt/speculative/eagle_worker.py b/python/sglang/srt/speculative/eagle_worker.py
+index 0086e2aa7..73dbe0d83 100644
+--- a/python/sglang/srt/speculative/eagle_worker.py
++++ b/python/sglang/srt/speculative/eagle_worker.py
+@@ -362,6 +362,7 @@ class EAGLEWorker(TpModelWorker):
+         # We need the full hidden states to prefill the KV cache of the draft model.
+         model_worker_batch = batch.get_model_worker_batch()
+         model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
++        model_worker_batch.has_spec_training = False  # Need proper sampling for EAGLE
+         batch_result = self.target_worker.forward_batch_generation(model_worker_batch)
+         logits_output, next_token_ids = (
+             batch_result.logits_output,
+@@ -538,10 +539,14 @@ class EAGLEWorker(TpModelWorker):
+ 
+         # Get forward batch
+         model_worker_batch = batch.get_model_worker_batch()
+-        assert model_worker_batch.capture_hidden_mode == CaptureHiddenMode.LAST
++        # Override capture_hidden_mode for EAGLE draft (spec_training_info forces FULL)
++        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
+         forward_batch = ForwardBatch.init_new(
+             model_worker_batch, self.draft_model_runner
+         )
++        # Draft model always needs logits for draft token selection, even when
++        # doing spec training data collection. Don't skip logits computation.
++        forward_batch.has_spec_training = False
+         can_cuda_graph = self.cuda_graph_runner and self.cuda_graph_runner.can_run(
+             forward_batch
+         )
+@@ -695,7 +700,13 @@ class EAGLEWorker(TpModelWorker):
+         model_worker_batch = batch.get_model_worker_batch(
+             seq_lens_cpu_cache=spec_info.seq_lens_cpu
+         )
+-        assert model_worker_batch.capture_hidden_mode == spec_info.capture_hidden_mode
++
++        if batch.spec_training_info is not None:
++            model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
++        else:
++            assert (
++                model_worker_batch.capture_hidden_mode == spec_info.capture_hidden_mode
++            )
+ 
+         if batch.has_grammar:
+             retrieve_next_token_cpu = spec_info.retrive_next_token.cpu()
+@@ -737,6 +748,20 @@ class EAGLEWorker(TpModelWorker):
+             detect_nan(logits_output)
+ 
+         spec_info.hidden_states = logits_output.hidden_states
++        # Only tp_rank 0 needs last_hidden_states for spec training (Mooncake store)
++        if self.tp_rank == 0:
++            spec_info.last_hidden_states = logits_output.last_hidden_states
++        else:
++            spec_info.last_hidden_states = None
++
++        # Temporarily hide spec_training_info on non-rank-0 to prevent
++        # verify() from cloning hidden states into per-request chunks
++        # (only rank 0 consumes them via _decode_hs_storage).
++        saved_spec_training_info = None
++        if self.tp_rank != 0 and batch.spec_training_info is not None:
++            saved_spec_training_info = batch.spec_training_info
++            batch.spec_training_info = None
++
+         res: EagleVerifyOutput = spec_info.verify(
+             batch,
+             logits_output,
+@@ -745,12 +770,20 @@ class EAGLEWorker(TpModelWorker):
+             vocab_mask,
+         )
+ 
++        if saved_spec_training_info is not None:
++            batch.spec_training_info = saved_spec_training_info
++
+         # Post process based on verified outputs.
+         # Pick indices that we care (accepted)
+         logits_output.next_token_logits = logits_output.next_token_logits[
+             res.accepted_indices
+         ]
+         logits_output.hidden_states = logits_output.hidden_states[res.accepted_indices]
++        # Also prune last_hidden_states for spec training (tp_rank 0 only)
++        if logits_output.last_hidden_states is not None and self.tp_rank == 0:
++            logits_output.last_hidden_states = logits_output.last_hidden_states[
++                res.accepted_indices
++            ]
+ 
+         if (
+             self.target_worker.model_runner.hybrid_gdn_config is not None
+@@ -876,10 +909,13 @@ class EAGLEWorker(TpModelWorker):
+         model_worker_batch = batch.get_model_worker_batch(
+             seq_lens_cpu_cache=seq_lens_cpu
+         )
++
++        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
+         forward_batch = ForwardBatch.init_new(
+             model_worker_batch, self.draft_model_runner
+         )
+         forward_batch.return_logprob = False
++        forward_batch.has_spec_training = False
+         logits_output = self.draft_model_runner.forward(forward_batch).logits_output
+         if self.enable_nan_detection:
+             detect_nan(logits_output)
+@@ -929,10 +965,14 @@ class EAGLEWorker(TpModelWorker):
+ 
+         batch.return_hidden_states = False
+         model_worker_batch = batch.get_model_worker_batch()
+-        assert model_worker_batch.capture_hidden_mode == CaptureHiddenMode.LAST
++        # Override capture_hidden_mode for EAGLE draft (spec_training_info forces FULL)
++        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
+         forward_batch = ForwardBatch.init_new(
+             model_worker_batch, self.draft_model_runner
+         )
++        # Draft model always needs logits for draft token selection, even when
++        # doing spec training data collection. Don't skip logits computation.
++        forward_batch.has_spec_training = False
+         if forward_batch.seq_lens_cpu is not None:
+             forward_batch.seq_lens_sum = forward_batch.seq_lens_cpu.sum().item()
+         else:
+@@ -1002,6 +1042,46 @@ class EAGLEWorker(TpModelWorker):
+         )
+         return success, message
+ 
++    def update_weights_from_disk(self, recv_req):
++        """Override to update hot_token_id after weight loading.
++
++        When updating draft model weights, the model's hot_token_id is updated
++        from the new checkpoint's d2t/t2d mappings, but the EAGLE worker's
++        self.hot_token_id is not updated, causing token mapping mismatches.
++
++        This fix updates the EAGLE worker's hot_token_id after loading weights
++        and invalidates CUDA graphs that cached the old tensor reference.
++        """
++        logger.info(f"Updating draft model weights from {recv_req.model_path}")
++        success, message = super().update_weights_from_disk(recv_req)
++
++        if not success:
++            logger.error(f"Failed to update draft model weights: {message}")
++            return success, message
++
++        # Update hot_token_id from the newly loaded model
++        if self.draft_model_runner.model.hot_token_id is not None:
++            logger.info("Updating hot_token_id from newly loaded draft model")
++            self.hot_token_id = self.draft_model_runner.model.hot_token_id.to(
++                self.device
++            )
++        else:
++            logger.info("No hot_token_id in the new draft model")
++            self.hot_token_id = None
++
++        logger.info(
++            "Recapturing CUDA graphs with new hot_token_id (this may take a few minutes)"
++        )
++        with self.draft_tp_context(
++            self.draft_model_runner.tp_group
++        ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
++            self.init_cuda_graphs()
++
++        logger.info(
++            "Successfully updated draft model weights, hot_token_id, and recaptured CUDA graphs"
++        )
++        return success, message
++
+ 
+ @torch.compile(dynamic=True, disable=_is_npu)
+ def get_last_loc_large_page_size_top_k_1(

--- a/tools/apply_sglang_patch.sh
+++ b/tools/apply_sglang_patch.sh
@@ -1,12 +1,23 @@
 #!/bin/bash
 
-# To force apply a patch, run: ./tools/apply_sglang_patch.sh <absolute-path-to-sglang-repo>
-# Please note that this will overwrite all the local changes.
+# Apply sglang patch for TorchSpec.
+#
+# Usage:
+#   ./tools/apply_sglang_patch.sh <path-to-sglang-repo>           # base patch (prefill only)
+#   ./tools/apply_sglang_patch.sh --decode <path-to-sglang-repo>  # full patch (prefill + decode)
+#
+# Please note that this will overwrite all local changes and delete untracked files.
 
 set -e
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+PATCH_NAME="sglang.patch"
+if [ "${1:-}" = "--decode" ]; then
+    PATCH_NAME="sglang_decode.patch"
+    shift
+fi
 
 SGLANG_VERSION="${SGLANG_VERSION:-v0.5.8.post1}"
 SGLANG_DIR="$PROJECT_ROOT/docker/sglang/$SGLANG_VERSION"
@@ -23,9 +34,10 @@ if [ -z "$SGLANG_COMMIT" ]; then
     exit 1
 fi
 
-SGLANG_PATH="${1:?Usage: $0 <path-to-sglang-repo>}"
+SGLANG_PATH="${1:?Usage: $0 [--decode] <path-to-sglang-repo>}"
 
-PATCH_FILE="$PROJECT_ROOT/patches/sglang/$SGLANG_VERSION/sglang.patch"
+PATCH_FILE="$PROJECT_ROOT/patches/sglang/$SGLANG_VERSION/$PATCH_NAME"
+
 if [ ! -f "$PATCH_FILE" ]; then
     echo "Error: Patch file not found: $PATCH_FILE"
     exit 1

--- a/tools/convert_to_hf.py
+++ b/tools/convert_to_hf.py
@@ -313,6 +313,7 @@ def _load_tokenized_prompts(
         prompt_key=prompt_key,
         max_seq_length=max_seq_length,
         cache_dir=cache_dir or "./cache",
+        train_with_decode=False,
     )
     return load_conversation_dataset(args_ns)
 

--- a/torchspec/config/train_config.py
+++ b/torchspec/config/train_config.py
@@ -116,6 +116,7 @@ class TrainingConfig:
     seed: int = 0
     train_backend: str = "fsdp"
     train_env_vars: str = "{}"
+    train_with_decode: bool = False
     training_num_gpus_per_node: int = 1
     training_num_nodes: int = 1
     ttt_length: int = 7
@@ -123,9 +124,29 @@ class TrainingConfig:
 
 
 @dataclass
+class DecodeConfig:
+    """Config for train-with-decode mode (speculative decoding during training)."""
+
+    cuda_graph_max_bs: Optional[int] = None
+    max_new_tokens: int = 512
+    max_running_requests: Optional[int] = None
+    speculative_algorithm: Optional[str] = None
+    speculative_draft_model_path: Optional[str] = None
+    speculative_eagle_topk: Optional[int] = None
+    speculative_num_draft_tokens: Optional[int] = None
+    speculative_num_steps: Optional[int] = None
+    temperature: float = 1.0
+    top_k: int = -1
+    top_p: float = 1.0
+    weight_sync_enabled: bool = False
+    weight_sync_interval: int = 500
+
+
+@dataclass
 class Config:
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
     debug: DebugConfig = field(default_factory=DebugConfig)
+    decode: DecodeConfig = field(default_factory=DecodeConfig)
     inference: InferenceConfig = field(default_factory=InferenceConfig)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
     model: ModelConfig = field(default_factory=ModelConfig)
@@ -223,6 +244,7 @@ def load_config(
 
 # Sub-sections whose fields receive a name prefix when flattened.
 _PREFIXED_SECTIONS = {
+    "decode": "decode_",
     "mooncake": "mooncake_",
     "sglang": "sglang_",
 }
@@ -259,7 +281,7 @@ def config_to_flat_args(config: DictConfig) -> argparse.Namespace:
     # --- Computed / alias fields ---
     flat["world_size"] = flat["training_num_nodes"] * flat["training_num_gpus_per_node"]
     flat["rank"] = 0
-    flat["dynamic_loss_mask"] = flat["defer_tokenization"]
+    flat["dynamic_loss_mask"] = flat["defer_tokenization"] and not flat["train_with_decode"]
     flat["use_wandb"] = flat.get("use_wandb", False) or flat.get("report_to") == "wandb"
     flat["use_tensorboard"] = (
         flat.get("use_tensorboard", False) or flat.get("report_to") == "tensorboard"

--- a/torchspec/controller/inference_manager.py
+++ b/torchspec/controller/inference_manager.py
@@ -175,6 +175,7 @@ class AsyncInferenceManager:
 
         self._defer_tokenization = getattr(args, "defer_tokenization", False)
         self._return_hidden_states = getattr(args, "compute_logits_in_trainer", True)
+        self._train_with_decode = getattr(args, "train_with_decode", False)
 
         self._enable_perf_metrics = getattr(args, "enable_perf_metrics", True)
         self._perf_window_seconds: float = 10.0
@@ -437,7 +438,10 @@ class AsyncInferenceManager:
             try:
                 if self._enable_perf_metrics:
                     t0 = time.time()
-                outputs = await engine.generate.remote(
+                generate_method = (
+                    engine.generate_with_decode if self._train_with_decode else engine.generate
+                )
+                outputs = await generate_method.remote(
                     kwargs["data_ids"],
                     kwargs["input_ids_ref"],
                     kwargs["packed_loss_mask_list"],
@@ -464,6 +468,9 @@ class AsyncInferenceManager:
     def _parse_engine_output(self, entry: InferenceInput, output: dict) -> InferenceOutput | None:
         """Convert engine output dict to InferenceOutput."""
         if not isinstance(output, dict) or "mooncake_key" not in output:
+            logger.debug(
+                f"Skipping invalid engine output for data_id={entry.data_id}: {type(output)}"
+            )
             return None
 
         self._metrics.record(output)

--- a/torchspec/controller/loop.py
+++ b/torchspec/controller/loop.py
@@ -20,6 +20,8 @@
 
 """Pipeline training loop: main training loop with sync training and async inference."""
 
+import shutil
+import tempfile
 import time
 
 import ray
@@ -33,6 +35,40 @@ from torchspec.controller.eval import (
     update_checkpoint_eval_meta,
 )
 from torchspec.utils.logging import logger
+
+
+def _maybe_sync_draft_weights(args, completed_steps, train_group, inference_engines):
+    """Sync draft model weights to inference engines (decode mode only)."""
+    weight_sync_enabled = getattr(args, "decode_weight_sync_enabled", False)
+    weight_sync_interval = getattr(args, "decode_weight_sync_interval", 500)
+    if not (
+        getattr(args, "train_with_decode", False)
+        and weight_sync_enabled
+        and inference_engines
+        and weight_sync_interval > 0
+        and completed_steps > 0
+        and completed_steps % weight_sync_interval == 0
+    ):
+        return
+
+    # NOTE: uses local tmp dir; for multi-node, ensure output_dir is on shared filesystem.
+    tmp_dir = tempfile.mkdtemp(prefix="draft_weight_sync_")
+    try:
+        logger.info(f"Step {completed_steps}: saving draft model to {tmp_dir}")
+        train_group.save_draft_model_for_serving(tmp_dir)
+
+        logger.info(f"Step {completed_steps}: updating {len(inference_engines)} engine(s)")
+        update_results = ray.get(
+            [engine.update_weights_from_disk.remote(tmp_dir) for engine in inference_engines]
+        )
+        for i, res in enumerate(update_results):
+            log_fn = logger.info if res.get("success") else logger.warning
+            log_fn(f"Engine {i}: success={res.get('success')}, message={res.get('message')}")
+    except Exception:
+        logger.exception(f"Step {completed_steps}: weight sync failed, skipping")
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        logger.info(f"Cleaned up temp dir {tmp_dir}")
 
 
 def _is_save_interval_step(step: int, interval: int) -> bool:
@@ -279,6 +315,8 @@ def training_loop(
                 best_eval_score = update_checkpoint_eval_meta(
                     args.checkpoint_dir, completed_steps, eval_metrics, best_eval_score
                 )
+
+            _maybe_sync_draft_weights(args, completed_steps, train_group, inference_engines)
 
             # Check if epoch completed
             if steps_in_current_epoch >= steps_per_epoch:

--- a/torchspec/data/dataset.py
+++ b/torchspec/data/dataset.py
@@ -57,7 +57,7 @@ def _init_tokenize_worker(
 
 def _tokenize_single(args):
     """Worker function — tokenize one sample."""
-    messages, max_length = args
+    messages, max_length, train_with_decode = args
     processed = _worker_state["preprocess"](
         _worker_state["tokenizer"],
         [messages],
@@ -66,6 +66,7 @@ def _tokenize_single(args):
         is_preformatted=False,
         include_attention_mask=False,
         use_packed_loss_mask=True,
+        add_generation_prompt=train_with_decode,
         return_formatted_text=True,
         last_turn_loss_only=_worker_state.get("last_turn_loss_only", False),
     )
@@ -95,10 +96,10 @@ def _format_single(args):
     """
     Worker function — format only, skip tokenization.
     """
-    messages, _ = args
+    messages, _, train_with_decode = args
     messages = _normalize_conversation(messages)
     parser = _worker_state["parser"]
-    formatted = parser.format(messages)
+    formatted = parser.format(messages, add_generation_prompt=train_with_decode)
     if not formatted:
         return None
     return {"formatted_prompt": formatted}
@@ -139,10 +140,11 @@ def load_conversation_dataset(args):
         st = os.stat(args.train_data_path)
         file_stat = f"-{st.st_size}-{st.st_mtime}"
     last_turn_loss_only_flag = getattr(args, "last_turn_loss_only", False)
+    train_with_decode = getattr(args, "train_with_decode", False)
     cache_params = (
         f"{dataset_name}-{args.train_data_path}{file_stat}-{args.target_model_path}"
         f"-{max_length}-{chat_template_name}-ltlo={last_turn_loss_only_flag}"
-        f"-defer={defer_tokenization}"
+        f"-defer={defer_tokenization}-decode={train_with_decode}"
     )
     cache_key = hashlib.md5(cache_params.encode()).hexdigest()
     cache_dir = os.path.join(getattr(args, "cache_dir", "./cache"), "tokenized_dataset")
@@ -181,7 +183,7 @@ def load_conversation_dataset(args):
     )
 
     # Pass 2: process in parallel
-    work_items = [(messages, max_length) for _, messages, _ in raw_samples]
+    work_items = [(messages, max_length, train_with_decode) for _, messages, _ in raw_samples]
 
     if defer_tokenization:
         worker_init = _init_format_worker

--- a/torchspec/inference/engine/base.py
+++ b/torchspec/inference/engine/base.py
@@ -72,15 +72,6 @@ class InferenceEngine(ABC):
             List of dicts with mooncake_key or tensors.
         """
 
-    def update_weights_from_disk(self, model_path: str) -> dict:
-        """Update draft model weights from disk without restarting the engine.
-
-        Default implementation raises NotImplementedError.
-        """
-        raise NotImplementedError(
-            f"{type(self).__name__} does not support update_weights_from_disk"
-        )
-
     def get_mooncake_config(self):
         """Get the mooncake configuration.
 

--- a/torchspec/inference/engine/sgl_engine.py
+++ b/torchspec/inference/engine/sgl_engine.py
@@ -37,6 +37,7 @@ import torch
 from omegaconf import DictConfig, OmegaConf
 
 from torchspec.inference.engine.base import InferenceEngine
+from torchspec.inference.engine.sgl_engine_decode import SglDecodeEngineMixin
 from torchspec.ray.ray_actor import RayActor
 from torchspec.utils.logging import logger, setup_file_logging
 from torchspec.utils.misc import get_default_eagle3_aux_layer_ids, get_free_port
@@ -61,7 +62,7 @@ _PROTECTED_ENGINE_KEYS = frozenset(
 )
 
 
-class SglEngine(InferenceEngine, RayActor):
+class SglEngine(SglDecodeEngineMixin, InferenceEngine, RayActor):
     """Ray actor wrapper for sgl.Engine with distributed deployment support.
 
     Uses patched sglang's spec_training mode to generate training data and store
@@ -219,7 +220,6 @@ class SglEngine(InferenceEngine, RayActor):
         engine_kwargs.update(
             {
                 "model_path": self.args.target_model_path,
-                "disable_cuda_graph": True,
                 "disable_radix_cache": True,
                 "enable_return_hidden_states": True,
                 "enable_aux_hidden_states": True,
@@ -237,6 +237,13 @@ class SglEngine(InferenceEngine, RayActor):
                 **({"context_length": max_seq_length} if max_seq_length else {}),
             }
         )
+
+        # Decode mode: add speculative decoding and performance tuning params
+        self._train_with_decode = getattr(self.args, "train_with_decode", False)
+        if self._train_with_decode:
+            self._build_decode_engine_kwargs(engine_kwargs)
+        else:
+            engine_kwargs["disable_cuda_graph"] = True
 
         # Each engine needs 2 consecutive ports (service + NCCL).  Offset the
         # search start by rank so parallel engines on the same node never probe
@@ -496,7 +503,8 @@ class SglEngine(InferenceEngine, RayActor):
         """Get tensor shapes for mooncake metadata.
 
         Args:
-            seq_len: Sequence length for this sample (input length, not generated length).
+            seq_len: Sequence length for this sample (prompt length in prefill mode,
+                or prompt + completion - 1 in decode mode).
 
         Returns:
             Dict mapping tensor names to shapes.

--- a/torchspec/inference/engine/sgl_engine_decode.py
+++ b/torchspec/inference/engine/sgl_engine_decode.py
@@ -1,0 +1,315 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Decode-mode mixin for SglEngine.
+
+Provides speculative-decoding generation and draft model weight sync.
+Mixed into SglEngine when train_with_decode is enabled.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import ray
+import torch
+
+from torchspec.data.utils import serialize_packed_loss_mask
+from torchspec.utils.logging import logger
+
+
+class SglDecodeEngineMixin:
+    """Mixin that adds decode-mode generation and weight sync to SglEngine.
+
+    Expects the host class to provide: ``self.args``, ``self.rank``,
+    ``self._engine``, ``self._get_tensor_shapes()``, ``self._get_tensor_dtypes()``,
+    ``self._extract_image_data()``.
+    """
+
+    # -- Engine kwargs --------------------------------------------------------
+
+    # Mapping from args attr -> engine kwarg for optional decode params.
+    _DECODE_OPTIONAL_KWARGS = [
+        ("decode_cuda_graph_max_bs", "cuda_graph_max_bs"),
+        ("decode_max_running_requests", "max_running_requests"),
+    ]
+    _DECODE_SPEC_KWARGS = [
+        ("decode_speculative_num_steps", "speculative_num_steps"),
+        ("decode_speculative_eagle_topk", "speculative_eagle_topk"),
+        ("decode_speculative_num_draft_tokens", "speculative_num_draft_tokens"),
+        ("sglang_speculative_draft_attention_backend", "speculative_draft_attention_backend"),
+    ]
+
+    def _build_decode_engine_kwargs(self, engine_kwargs: dict) -> None:
+        """Populate *engine_kwargs* with decode-mode speculative decoding params."""
+        for attr, kwarg in self._DECODE_OPTIONAL_KWARGS:
+            if (val := getattr(self.args, attr, None)) is not None:
+                engine_kwargs[kwarg] = val
+
+        spec_algorithm = getattr(self.args, "decode_speculative_algorithm", None)
+        if not spec_algorithm:
+            return
+
+        spec_draft_path = getattr(self.args, "decode_speculative_draft_model_path", None)
+        if spec_draft_path is None:
+            raise ValueError(
+                "decode.speculative_draft_model_path is null. It is normally auto-created "
+                "by _maybe_create_scratch_draft when train_with_decode=true. Set it "
+                "explicitly or check that speculative_algorithm is configured correctly."
+            )
+        engine_kwargs["speculative_algorithm"] = spec_algorithm
+        engine_kwargs["speculative_draft_model_path"] = spec_draft_path
+        engine_kwargs["speculative_draft_model_quantization"] = "unquant"
+
+        for attr, kwarg in self._DECODE_SPEC_KWARGS:
+            if (val := getattr(self.args, attr, None)) is not None:
+                engine_kwargs[kwarg] = val
+
+        logger.info(
+            f"SglEngine rank {self.rank}: decode mode enabled with "
+            f"algorithm={spec_algorithm}, draft={spec_draft_path}"
+        )
+
+    # -- Generation -----------------------------------------------------------
+
+    def generate_with_decode(
+        self,
+        data_id: str | list[str],
+        input_ids_ref: ray.ObjectRef | list[torch.Tensor] | None = None,
+        packed_loss_mask_list: list[str] | None = None,
+        formatted_prompts: list[str] | None = None,
+        return_last_hidden_states: bool = False,
+        return_logits: bool = True,
+        multimodal_inputs: list[dict] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Generate training data with decoding (spec training with actual token generation).
+
+        Unlike generate() which does prefill-only, this method generates new tokens
+        and captures hidden states for the full prompt+completion sequence.
+
+        Accepts either pre-tokenized input_ids or formatted prompt strings.
+        Exactly one of input_ids_ref or formatted_prompts must be set.
+
+        Args:
+            data_id: Data ID(s) for the batch.
+            input_ids_ref: Ray ObjectRef or list of input_ids tensors.
+            packed_loss_mask_list: List of packed loss_mask strings.
+            formatted_prompts: List of already chat-template-formatted prompt strings.
+            return_last_hidden_states: Ignored, always stored in mooncake.
+            return_logits: Ignored, always stored in mooncake.
+            multimodal_inputs: List of multimodal input dicts.
+
+        Returns:
+            List of dicts with mooncake_key and tensor metadata.
+            Returns None entries for samples where mooncake storage failed.
+        """
+        if self._engine is None:
+            raise RuntimeError("SglEngine not initialized. Call init() first.")
+
+        if (input_ids_ref is None) == (formatted_prompts is None):
+            raise ValueError("Exactly one of input_ids_ref or formatted_prompts must be set")
+
+        use_prompts = formatted_prompts is not None
+
+        if use_prompts:
+            batch_size = len(formatted_prompts)
+        else:
+            if isinstance(input_ids_ref, ray.ObjectRef):
+                input_ids_list = ray.get(input_ids_ref)
+            else:
+                input_ids_list = input_ids_ref
+            batch_size = len(input_ids_list)
+
+        if isinstance(data_id, str):
+            data_ids = [f"{data_id}_{i}" for i in range(batch_size)]
+        elif len(data_id) == batch_size:
+            data_ids = data_id
+        else:
+            raise ValueError(
+                f"data_id length {len(data_id)} does not match batch size {batch_size}"
+            )
+
+        # Build sampling params for decode mode
+        max_new_tokens = getattr(self.args, "decode_max_new_tokens", 512)
+        sampling_params = {"max_new_tokens": max_new_tokens}
+        temperature = getattr(self.args, "decode_temperature", 1.0)
+        if temperature != 1.0:
+            sampling_params["temperature"] = temperature
+        top_p = getattr(self.args, "decode_top_p", 1.0)
+        if top_p < 1.0:
+            sampling_params["top_p"] = top_p
+        top_k = getattr(self.args, "decode_top_k", -1)
+        if top_k > 0:
+            sampling_params["top_k"] = top_k
+
+        if use_prompts:
+            logger.debug(
+                f"SglEngine rank {self.rank}: decode prompt mode processing data_ids={data_ids}, "
+                f"num_prompts={len(formatted_prompts)}"
+            )
+            engine_kwargs = {
+                "prompt": formatted_prompts,
+                "spec_training_data_id": data_ids,
+                "sampling_params": sampling_params,
+                "return_hidden_states": True,
+            }
+        else:
+            input_ids_list_of_lists = []
+            for ids in input_ids_list:
+                if ids.dim() == 2 and ids.shape[0] == 1:
+                    ids = ids.squeeze(0)
+                elif ids.dim() > 2:
+                    raise ValueError(f"Unexpected input_ids shape: {ids.shape}")
+                input_ids_list_of_lists.append(ids.tolist())
+
+            logger.debug(
+                f"SglEngine rank {self.rank}: decode mode processing data_ids={data_ids}, "
+                f"shapes: {[len(ids) for ids in input_ids_list_of_lists]}"
+            )
+            engine_kwargs = {
+                "input_ids": input_ids_list_of_lists,
+                "spec_training_data_id": data_ids,
+                "packed_loss_mask": packed_loss_mask_list,
+                "sampling_params": sampling_params,
+                "return_hidden_states": True,
+            }
+
+        image_data = self._extract_image_data(multimodal_inputs)
+        if image_data is not None:
+            engine_kwargs["image_data"] = image_data
+
+        results = self._engine.generate(**engine_kwargs)
+
+        # IMPORTANT: Must produce exactly one output per input result to match
+        # the zip(entries, outputs, strict=True) in the inference manager.
+        outputs = []
+        for i, result in enumerate(results):
+            store_keys = result["meta_info"].get("spec_training_mooncake_store_keys", [])
+            if not store_keys:
+                logger.warning(
+                    f"SglEngine rank {self.rank}: No mooncake keys returned for "
+                    f"data_id={data_ids[i]}, skipping this sample."
+                )
+                outputs.append(None)
+                continue
+
+            meta_info = result["meta_info"]
+            if "e2e_latency" in meta_info:
+                metrics_msg = (
+                    f"SglEngine rank {self.rank}: DECODE "
+                    f"e2e_latency={meta_info['e2e_latency']:.4f}s"
+                )
+                if "spec_accept_rate" in meta_info:
+                    metrics_msg += f", spec_accept_rate={meta_info['spec_accept_rate']:.2%}"
+                if "spec_accept_length" in meta_info:
+                    metrics_msg += f", spec_accept_length={meta_info['spec_accept_length']:.2f}"
+                logger.debug(metrics_msg)
+
+            key = store_keys[0]
+            prompt_tokens = meta_info.get("prompt_tokens", 0)
+            completion_tokens = meta_info.get("completion_tokens", 0)
+            if completion_tokens > 0:
+                seq_len = prompt_tokens + completion_tokens - 1
+            else:
+                logger.warning(
+                    f"SglEngine rank {self.rank}: completion_tokens=0 for "
+                    f"data_id={data_ids[i]}, sample will produce zero loss"
+                )
+                seq_len = prompt_tokens
+            logger.debug(
+                f"SglEngine rank {self.rank}: decode mode - "
+                f"prompt={prompt_tokens}, completion={completion_tokens}, "
+                f"seq_len={seq_len}"
+            )
+
+            tensor_shapes = self._get_tensor_shapes(seq_len)
+            logger.debug(
+                f"SglEngine rank {self.rank}: mooncake_key={key}, seq_len={seq_len}, "
+                f"tensor_shapes={tensor_shapes}"
+            )
+
+            # Build loss mask: skip prompt tokens, compute loss on completion tokens.
+            # The -1 accounts for next-token prediction (last token has no target).
+            if completion_tokens > 0:
+                loss_mask = serialize_packed_loss_mask([prompt_tokens, completion_tokens - 1])
+            else:
+                loss_mask = serialize_packed_loss_mask([prompt_tokens])
+
+            output_dict = {
+                "mooncake_key": key,
+                "tensor_shapes": tensor_shapes,
+                "tensor_dtypes": self._get_tensor_dtypes(),
+                "packed_loss_mask": loss_mask,
+            }
+
+            # Add performance metrics if available (for wandb logging)
+            _METRIC_KEYS = (
+                "e2e_latency",
+                "spec_accept_rate",
+                "spec_accept_length",
+                "prompt_tokens",
+                "completion_tokens",
+            )
+            output_dict.update({k: meta_info[k] for k in _METRIC_KEYS if k in meta_info})
+
+            outputs.append(output_dict)
+
+        logger.debug(
+            f"SglEngine rank {self.rank}: decode generated {len(outputs)} mooncake keys "
+            f"for data_ids={data_ids}"
+        )
+        return outputs
+
+    # -- Weight sync ----------------------------------------------------------
+
+    def update_weights_from_disk(self, model_path: str) -> dict:
+        """Update draft model weights from disk without restarting the engine.
+
+        Args:
+            model_path: Path to the saved draft model weights.
+
+        Returns:
+            Dict with 'success' and 'message' keys.
+        """
+        from sglang.srt.managers.io_struct import UpdateWeightFromDiskReqInput
+
+        if self._engine is None:
+            return {"success": False, "message": "Engine not initialized"}
+
+        obj = UpdateWeightFromDiskReqInput(
+            model_path=model_path,
+            update_draft_model=True,
+            flush_cache=True,
+        )
+
+        # sgl.Engine.update_weights_from_disk() does not expose update_draft_model=True.
+        # Access the internal event loop and tokenizer_manager directly to pass this flag.
+        result = self._engine.loop.run_until_complete(
+            self._engine.tokenizer_manager.update_weights_from_disk(obj, None)
+        )
+
+        success = getattr(result, "success", False)
+        message = getattr(result, "message", str(result))
+        logger.info(
+            f"SglEngine rank {self.rank}: update_weights_from_disk "
+            f"-> success={success}, message={message}"
+        )
+        return {"success": success, "message": message}

--- a/torchspec/train_entry.py
+++ b/torchspec/train_entry.py
@@ -21,6 +21,7 @@
 """Training entry point for Eagle3 speculative decoding."""
 
 import argparse
+import os
 import sys
 import time
 from collections import namedtuple
@@ -101,10 +102,10 @@ def parse_config():
     """Parse YAML config and convert to flat args.
 
     Supports configs with sections matching the Config dataclass:
-    model, dataset, training, debug, inference, logging, mooncake.
+    model, dataset, training, debug, inference, logging, mooncake, decode.
 
-    The config is flattened via config_to_flat_args(), with mooncake and
-    inference.sglang sections getting a name prefix (mooncake_*, sglang_*).
+    The config is flattened via config_to_flat_args(), with prefixed sections:
+    mooncake_*, sglang_*, decode_*.
     """
 
     parser = argparse.ArgumentParser(description="Eagle3 speculative decoding training")
@@ -145,6 +146,21 @@ def parse_config():
     return flat_args
 
 
+def _maybe_create_scratch_draft(args, train_group):
+    """Auto-create scratch draft checkpoint for inference engine if not provided."""
+    if (
+        getattr(args, "train_with_decode", False)
+        and getattr(args, "decode_speculative_algorithm", None)
+        and getattr(args, "decode_speculative_draft_model_path", None) is None
+    ):
+        scratch_dir = os.path.join(getattr(args, "output_dir", "./outputs"), "scratch_draft_model")
+        os.makedirs(scratch_dir, exist_ok=True)
+        logger.info(f"Auto-creating scratch draft checkpoint at {scratch_dir}")
+        train_group.save_draft_model_for_serving(scratch_dir)
+        args.decode_speculative_draft_model_path = scratch_dir
+        logger.info(f"Set decode_speculative_draft_model_path = {scratch_dir}")
+
+
 def _resolve_batch_size(args):
     """Derive dp_size, per_dp_rank_batch_size, dispatch_batch_size, and global_batch_size."""
     dp_size = (
@@ -175,14 +191,18 @@ def _get_draft_model_config(args):
 
 
 def train_async_no_generation(args):
-    """Entry point for Eagle3 distillation training without generation.
+    """Entry point for Eagle3 online training.
 
-    Uses distributed HFEngine Ray actors with placement groups for multi-node deployment.
-    Engines are scheduled across nodes and communicate via Ray.
-    Each engine stores tensors in mooncake and returns keys to AsyncInferenceManager.
-
-    Mooncake master is launched as a Ray actor to handle tensor storage coordination.
+    Supports prefill-only mode (default) and decode mode (train_with_decode=True)
+    with speculative decoding. Uses distributed Ray actors with placement groups.
+    Engines store tensors in mooncake and return keys to AsyncInferenceManager.
     """
+    if (
+        getattr(args, "train_with_decode", False)
+        and getattr(args, "inference_engine_type", "sgl") != "sgl"
+    ):
+        raise ValueError("train_with_decode=True requires inference_engine_type=sgl")
+
     init_tracking(args)
     timer = _InitTimer()
 
@@ -249,6 +269,12 @@ def train_async_no_generation(args):
         train_init_refs = train_group.async_init(
             args, role="training", mooncake_config=mooncake_config, with_ref=False
         )
+
+        # Decode mode: create scratch draft checkpoint before inference engines
+        # are prepared, since they need decode_speculative_draft_model_path on args.
+        # This blocks on train actor init (FSDP gather), so inference engines are
+        # dispatched after to maximize parallelism with the wait below.
+        _maybe_create_scratch_draft(args, train_group)
 
         inference_engines, engine_init_refs = prepare_inference_engines(
             args, pgs["inference"], mooncake_config


### PR DESCRIPTION
## Summary
- Add decode-mode training where the inference engine generates new tokens with speculative decoding and captures hidden states for the full prompt+completion sequence
- Add `DecodeConfig` dataclass, `SglDecodeEngineMixin` for decode-mode generation and draft weight sync, sglang decode patch, configs, and example scripts
- Integrate into training loop with periodic draft model weight sync to inference engines

## Changes
- `torchspec/config/train_config.py`: Add `train_with_decode` flag, `DecodeConfig` dataclass, update `dynamic_loss_mask` conditional
- `torchspec/inference/engine/sgl_engine_decode.py`: New mixin with `generate_with_decode()` and `update_weights_from_disk()`
- `torchspec/inference/engine/sgl_engine.py`: Inherit `SglDecodeEngineMixin`, add decode engine kwargs
- `torchspec/controller/inference_manager.py`: Conditional dispatch (generate vs generate_with_decode)
- `torchspec/controller/loop.py`: `_maybe_sync_draft_weights()` for periodic draft model updates
- `torchspec/train_entry.py`: `_maybe_create_scratch_draft()`, startup validation for decode mode
- `torchspec/data/dataset.py`: Pass `train_with_decode` as `add_generation_prompt` through data pipeline
- `patches/sglang/v0.5.8.post1/sglang_decode.patch`: Full sglang patch for decode-mode support
- `tools/apply_sglang_patch.sh`: Add `--decode` flag to apply decode patch
- `tools/convert_to_hf.py`: Add `train_with_decode=False` parameter
- `configs/train_with_decode/`: Qwen3-8B and Kimi-K2.5-NVFP4 decode-mode configs
- `examples/train-with-decode/`: Launch scripts for decode-mode training

## Test plan
- [x] All 232 existing tests pass (0 failures)
- [x] ruff lint + format checks pass
- [x] Pre-commit hooks pass
- [ ] Manual integration test with decode-mode config

## Acknowledgements
Co-authored-by: BobbyIsHandsome <96061080+BobbyIsHandsome@users.noreply.github.com>
Co-authored-by: Junxiong Wang <16102460+jxiw@users.noreply.github.com>
Co-authored-by: xwuShirley <37637998+xwuShirley@users.noreply.github.com>
Co-authored-by: Yubo Wang <10526540+yubofredwang@users.noreply.github.com>

Generated with [Claude Code](https://claude.com/claude-code)