### PR TITLE
[Feature] add placement_strategy config to control head-node GPU assignment

### DIFF
--- a/torchspec/config/train_config.py
+++ b/torchspec/config/train_config.py
@@ -97,6 +97,9 @@ class TrainingConfig:
     distributed_timeout_minutes: int = 10
     draft_accumulation_steps: int = 1
     fsdp_strategy: str = "REPLICATE"
+    # Controls which workload claims head-node GPUs first under PACK strategy.
+    # "training_first" (default) or "inference_first". Extensible to custom mappings later.
+    placement_strategy: str = "training_first"
 
     gradient_checkpointing: bool = False
     learning_rate: float = 1e-4

--- a/torchspec/ray/placement_group.py
+++ b/torchspec/ray/placement_group.py
@@ -193,15 +193,30 @@ def create_placement_groups(args):
         f"{num_training_gpus} GPUs for training..."
     )
 
-    logger.info("Creating inference placement group...")
-    inference_pg, inference_bundle_indices, inference_gpu_ids = _create_placement_group(
-        num_inference_gpus, strategy="PACK", name="inference_pg"
-    )
+    placement_strategy = getattr(args, "placement_strategy", "training_first")
 
-    logger.info("Creating training placement group...")
-    training_pg, training_bundle_indices, training_gpu_ids = _create_placement_group(
-        num_training_gpus, strategy="PACK", name="training_pg"
-    )
+    if placement_strategy == "training_first":
+        logger.info(
+            "Creating training placement group first (placement_strategy=training_first)..."
+        )
+        training_pg, training_bundle_indices, training_gpu_ids = _create_placement_group(
+            num_training_gpus, strategy="PACK", name="training_pg"
+        )
+        logger.info("Creating inference placement group...")
+        inference_pg, inference_bundle_indices, inference_gpu_ids = _create_placement_group(
+            num_inference_gpus, strategy="PACK", name="inference_pg"
+        )
+    else:
+        logger.info(
+            "Creating inference placement group first (placement_strategy=inference_first)..."
+        )
+        inference_pg, inference_bundle_indices, inference_gpu_ids = _create_placement_group(
+            num_inference_gpus, strategy="PACK", name="inference_pg"
+        )
+        logger.info("Creating training placement group...")
+        training_pg, training_bundle_indices, training_gpu_ids = _create_placement_group(
+            num_training_gpus, strategy="PACK", name="training_pg"
+        )
 
     return {
         "training": (training_pg, training_bundle_indices, training_gpu_ids),


### PR DESCRIPTION
With Ray's PACK strategy the first placement group created claims head-node GPUs.  A new `training.placement_strategy` field ("inference_first" | "training_first") lets callers choose which workload lands on the head node.  Default is "training_first" (preserving current behaviour).