### PR TITLE
[Feature] Windowed eval submission to prevent Mooncake store OOM

### DIFF
--- a/tests/test_capacity_handling.py
+++ b/tests/test_capacity_handling.py
@@ -494,7 +494,11 @@ class TestEvalDispatch:
     def _setup_eval_and_push(self, controller, num_samples):
         """Set up eval dataset, push all inference results, return the eval data_ids."""
         dataset = [{"prompt": f"eval prompt {i}", "data_id": f"s{i}"} for i in range(num_samples)]
-        controller.set_eval_dataset(dataset)
+        eval_entries = controller._build_eval_entries(dataset)
+        controller._eval_expected_count = num_samples
+        controller._eval_dispatched_samples = 0
+        with controller._prompt_lock:
+            controller.prompt_buffer.extendleft(reversed(eval_entries))
 
         eval_data_ids = sorted(controller._eval_data_ids)
         results = [
@@ -560,7 +564,11 @@ class TestEvalDispatch:
         controller = self._create_controller(max_sample_pool_size=4)
 
         dataset = [{"prompt": f"eval prompt {i}", "data_id": f"s{i}"} for i in range(8)]
-        controller.set_eval_dataset(dataset)
+        eval_entries = controller._build_eval_entries(dataset)
+        controller._eval_expected_count = 8
+        controller._eval_dispatched_samples = 0
+        with controller._prompt_lock:
+            controller.prompt_buffer.extendleft(reversed(eval_entries))
 
         partial_ids = sorted(controller._eval_data_ids)[:4]
         results = [
@@ -603,7 +611,7 @@ class TestEvalDispatch:
 
 
 class TestEvalEndToEnd:
-    """End-to-end eval flow: set_eval_dataset → push results → dispatch batches → finalize."""
+    """End-to-end eval flow: submit chunks → push results → dispatch batches → finalize."""
 
     def _create_controller(self, max_sample_pool_size=2, dp_size=2):
         AsyncTrainingController = _create_controller_class()
@@ -618,7 +626,11 @@ class TestEvalEndToEnd:
 
         num_samples = 7
         dataset = [{"prompt": f"eval prompt {i}", "data_id": f"e{i}"} for i in range(num_samples)]
-        controller.set_eval_dataset(dataset)
+        eval_entries = controller._build_eval_entries(dataset)
+        controller._eval_expected_count = num_samples
+        controller._eval_dispatched_samples = 0
+        with controller._prompt_lock:
+            controller.prompt_buffer.extendleft(reversed(eval_entries))
 
         eval_data_ids = sorted(controller._eval_data_ids)
         results = [

--- a/tests/test_loop_cleanup.py
+++ b/tests/test_loop_cleanup.py
@@ -89,6 +89,7 @@ def test_generate_eval_cache_dispatches_and_finalizes():
         eval_dispatch_bs=2,
         eval_dataset_size=8,
         dp_size=2,
+        initial_eval_submit_count=8,
     )
 
     with (
@@ -100,6 +101,48 @@ def test_generate_eval_cache_dispatches_and_finalizes():
     assert train_group.cache_eval_samples.call_count == 4
     train_group.cache_eval_samples.assert_called_with(1)
     controller.finalize_eval_dispatch.remote.assert_called_once()
+
+
+def test_generate_eval_cache_interleaves_refill_and_drain_without_stalling():
+    controller = mock.MagicMock()
+    train_group = mock.MagicMock()
+
+    controller.try_dispatch_eval_batch.remote.side_effect = [
+        False,
+        True,
+        False,
+        True,
+        False,
+        True,
+        False,
+        True,
+    ]
+
+    state = eval_utils.EvalSetupState(
+        eval_interval=0,
+        eval_enabled=True,
+        eval_cache_loaded=False,
+        eval_cache_path=None,
+        best_eval_score=0.0,
+        eval_dispatch_bs=2,
+        eval_dataset_size=8,
+        dp_size=2,
+        initial_eval_submit_count=4,
+    )
+
+    with (
+        mock.patch("torchspec.controller.eval.ray.get", side_effect=lambda x: x),
+        mock.patch("torchspec.controller.eval.time.sleep") as mock_sleep,
+    ):
+        eval_utils.generate_eval_cache(controller, train_group, state)
+
+    assert train_group.cache_eval_samples.call_count == 4
+    assert controller.submit_eval_chunk.remote.call_args_list == [
+        mock.call(4, 6),
+        mock.call(6, 8),
+    ]
+    controller.finalize_eval_dispatch.remote.assert_called_once()
+    assert mock_sleep.call_count == 4
 
 
 def test_generate_eval_cache_times_out_when_eval_never_arrives():
@@ -115,6 +158,7 @@ def test_generate_eval_cache_times_out_when_eval_never_arrives():
         eval_dispatch_bs=2,
         eval_dataset_size=8,
         dp_size=2,
+        initial_eval_submit_count=4,
     )
 
     controller.try_dispatch_eval_batch.remote.return_value = False
@@ -135,7 +179,7 @@ def test_setup_eval_dispatch_bs_is_dp_size():
     controller = mock.MagicMock()
     train_group = mock.MagicMock()
     train_group.load_eval_cache.return_value = [0]
-    controller.submit_eval_dataset.remote.return_value = 16
+    controller.submit_eval_chunk.remote.return_value = 4
 
     args = SimpleNamespace(
         eval_interval=50,
@@ -159,14 +203,15 @@ def test_setup_eval_dispatch_bs_is_dp_size():
     assert state.eval_enabled is True
     assert state.eval_dispatch_bs == 2
     assert state.eval_dataset_size == 16
-    controller.submit_eval_dataset.remote.assert_called_once()
+    assert state.initial_eval_submit_count == 4
+    controller.submit_eval_chunk.remote.assert_called_once_with(0, 4)
 
 
 def test_setup_eval_dispatch_bs_caps_at_dataset_size():
     controller = mock.MagicMock()
     train_group = mock.MagicMock()
     train_group.load_eval_cache.return_value = [0]
-    controller.submit_eval_dataset.remote.return_value = 4
+    controller.submit_eval_chunk.remote.return_value = 4
 
     args = SimpleNamespace(
         eval_interval=50,
@@ -188,3 +233,5 @@ def test_setup_eval_dispatch_bs_caps_at_dataset_size():
         )
 
     assert state.eval_dispatch_bs == 4
+    assert state.initial_eval_submit_count == 4
+    controller.submit_eval_chunk.remote.assert_called_once_with(0, 4)

--- a/torchspec/controller/eval.py
+++ b/torchspec/controller/eval.py
@@ -46,6 +46,7 @@ class EvalSetupState:
     eval_dispatch_bs: int
     eval_dataset_size: int
     dp_size: int
+    initial_eval_submit_count: int = 0
 
 
 def _check_idle_timeout(
@@ -112,6 +113,7 @@ def generate_eval_cache(
         f"({eval_dataset_size} samples, dispatch_bs={dispatch_bs})..."
     )
     dispatched_samples = 0
+    next_submit_idx = eval_state.initial_eval_submit_count
     eval_progress = tqdm(total=eval_dataset_size, desc="Eval caching", unit="sample")
 
     while dispatched_samples < eval_dataset_size:
@@ -119,6 +121,10 @@ def generate_eval_cache(
         if ok:
             train_group.cache_eval_samples(dispatch_bs // dp_size)
             dispatched_samples += dispatch_bs
+            if next_submit_idx < eval_dataset_size:
+                next_end = min(next_submit_idx + dispatch_bs, eval_dataset_size)
+                ray.get(controller.submit_eval_chunk.remote(next_submit_idx, next_end))
+                next_submit_idx = next_end
             last_progress_at = time.monotonic()
             eval_progress.update(dispatch_bs)
         else:
@@ -159,6 +165,7 @@ def setup_eval(controller, train_group, args, eval_dataset_size: int) -> EvalSet
     eval_enabled = eval_dataset_size > 0
     eval_cache_path: str | None = None
     eval_cache_loaded = False
+    initial_eval_submit_count = 0
 
     eval_dispatch_bs = min(args.dp_size, eval_dataset_size)
 
@@ -187,8 +194,12 @@ def setup_eval(controller, train_group, args, eval_dataset_size: int) -> EvalSet
                 f"Eval: loaded cached tensors from {eval_cache_path} ({loaded[0]} batches per rank)"
             )
         else:
-            ray.get(controller.submit_eval_dataset.remote())
-            logger.info(f"Eval: {eval_dataset_size} samples, dispatch_bs={eval_dispatch_bs}")
+            initial_eval_submit_count = min(eval_dataset_size, eval_dispatch_bs * 2)
+            ray.get(controller.submit_eval_chunk.remote(0, initial_eval_submit_count))
+            logger.info(
+                f"Eval: {eval_dataset_size} samples, dispatch_bs={eval_dispatch_bs}, "
+                f"initial_submit={initial_eval_submit_count}"
+            )
 
     return EvalSetupState(
         eval_interval=eval_interval,
@@ -199,4 +210,5 @@ def setup_eval(controller, train_group, args, eval_dataset_size: int) -> EvalSet
         eval_dispatch_bs=eval_dispatch_bs,
         eval_dataset_size=eval_dataset_size,
         dp_size=args.dp_size,
+        initial_eval_submit_count=initial_eval_submit_count,
     )

--- a/torchspec/controller/training_controller.py
+++ b/torchspec/controller/training_controller.py
@@ -247,11 +247,6 @@ class AsyncTrainingController:
         logger.info(f"Controller loaded eval dataset: {count} samples from {eval_data_path}")
         return count
 
-    def submit_eval_dataset(self) -> int:
-        """Submit the stored eval dataset for inference (prepended with high priority)."""
-        assert self._stored_eval_dataset is not None, "No stored eval dataset"
-        return self.set_eval_dataset(self._stored_eval_dataset)
-
     def get_dataset_size(self) -> int:
         if self._stored_dataset is None:
             raise RuntimeError(
@@ -476,19 +471,7 @@ class AsyncTrainingController:
     # Eval Pipeline
     # ─────────────────────────────────────────────────────────────
 
-    def set_eval_dataset(self, dataset: list) -> int:
-        """Push eval samples into the prompt buffer for inference.
-
-        Eval data_ids are tracked so that inference results are routed to
-        the eval pool instead of the training sample pool.
-
-        Eval samples are prepended (high priority) so they are processed
-        before queued training data — otherwise backpressure on the
-        training pool can starve eval indefinitely.
-        """
-        self._eval_expected_count = len(dataset)
-        self._eval_dispatched_samples = 0
-
+    def _build_eval_entries(self, dataset: list) -> list[InferenceInput]:
         eval_entries: list[InferenceInput] = []
         for sample in dataset:
             if isinstance(sample, dict):
@@ -509,11 +492,28 @@ class AsyncTrainingController:
                 self._eval_data_ids.add(data_id)
                 entry = InferenceInput(data_id=data_id, prompt=sample)
             eval_entries.append(entry)
+        return eval_entries
+
+    def submit_eval_chunk(self, start: int, end: int) -> int:
+        """Submit a slice of the stored eval dataset for inference."""
+        assert self._stored_eval_dataset is not None, "No stored eval dataset"
+        chunk = self._stored_eval_dataset[start:end]
+        if not chunk:
+            return 0
+
+        if start == 0:
+            self._eval_expected_count = len(self._stored_eval_dataset)
+            self._eval_dispatched_samples = 0
+
+        eval_entries = self._build_eval_entries(chunk)
 
         with self._prompt_lock:
             self.prompt_buffer.extendleft(reversed(eval_entries))
-        logger.info(f"Eval: prepended {len(dataset)} samples to prompt buffer (high priority)")
-        return len(dataset)
+        logger.info(
+            f"Eval: submitted chunk [{start}:{end}] "
+            f"({len(chunk)} samples, total_expected={self._eval_expected_count})"
+        )
+        return len(chunk)
 
     def get_eval_pool_size(self) -> int:
         with self._eval_pool_lock:


### PR DESCRIPTION
Eval cache generation previously submitted the entire eval dataset to the prompt buffer at once, which could overflow the Mooncake store before the wave-based drain had a chance to free space.

Replace the all-at-once submission with a fixed sliding window: only 2 dispatch waves are outstanding initially, and one new wave is submitted after each successful drain. This keeps Mooncake occupancy bounded without exposing any new user-facing config knobs.

- Add submit_eval_chunk(start, end) for incremental eval submission
- Remove set_eval_dataset / submit_eval_dataset (no longer needed)
- Extract _build_eval_entries for shared entry construction
- Add EvalSetupState.initial_eval_submit_count to track window cursor
- Add regression test for interleaved refill/drain without stalling