### PR TITLE
Fix Mooncake connector for hybrid KV cache models and chunked prefill

### DIFF
--- a/configs/vllm_qwen3_5_35b.yaml
+++ b/configs/vllm_qwen3_5_35b.yaml
@@ -1,0 +1,79 @@
+# Configuration for train_entry.py with vLLM Engine inference (nested config format)
+#
+# GPU allocation:
+#   - 4 GPUs for inference (TP=4 for Qwen3.5-35B-A3B)
+#   - 4 GPUs for training (DP/FSDP: model sharded across 4 GPUs)
+#   - Total: 8 GPUs
+#
+# Installation:
+#   pip install -e ".[vllm]"  # Install vLLM backend
+#
+# Usage:
+#   python -m torchspec.train_entry --config configs/vllm_qwen3_35b.yaml
+#
+# Note: Uses vLLM's extract_hidden_states speculative method with MooncakeHiddenStatesConnector.
+
+model:
+  target_model_path: Qwen/Qwen3.5-35B-A3B
+  embedding_key: model.language_model.embed_tokens.weight
+  lm_head_key: lm_head.weight
+  norm_key: model.language_model.norm.weight
+  trust_remote_code: true
+
+dataset:
+  train_data_path: ??
+  eval_data_path: ??
+  eval_interval: 1000
+  chat_template: qwen
+  prompt_key: conversations
+  defer_tokenization: true
+
+
+training:
+  attention_backend: fa4
+  micro_batch_size: 1
+  draft_accumulation_steps: 1
+  learning_rate: 1e-4
+  max_concurrent_batches: 1
+  max_grad_norm: 2.0
+  max_seq_length: 65536
+  num_epochs: 3
+  seed: 42
+  training_num_gpus_per_node: 2
+  training_num_nodes: 1
+  ttt_length: 4
+  save_per_epoch: true
+  warmup_ratio: 0.015
+  save_interval: 5000
+
+inference:
+  inference_engine_type: vllm
+  inference_num_gpus: 2
+  inference_num_gpus_per_engine: 1
+  inference_num_gpus_per_node: 4
+  max_sample_pool_size: 64
+  inference_buffer_threshold: 32
+  inference_batch_size: 2
+  aux_hidden_states_layers: [3, 19, 35]
+  vllm:
+    tp_size: 1
+    extra_args:
+      max_num_batched_tokens: 65536
+      enable_chunked_prefill: true
+      enforce_eager: true
+
+mooncake:
+  protocol: tcp
+  global_segment_size: 128GB
+  local_buffer_size: 8GB
+  master_server_address: null
+  metadata_server: null
+
+output_dir: ./outputs/qwen3_5-35b-single-node
+cache_dir: ./cache/qwen3_5-35b-single-node
+model_download_dir: null
+
+debug:
+  save_debug_train_data: null
+  debug_train_only: false
+  debug_inference_only: false

--- a/configs/vllm_qwen3_5_35b.yaml
+++ b/configs/vllm_qwen3_5_35b.yaml
@@ -1,9 +1,9 @@
 # Configuration for train_entry.py with vLLM Engine inference (nested config format)
 #
 # GPU allocation:
-#   - 4 GPUs for inference (TP=4 for Qwen3.5-35B-A3B)
-#   - 4 GPUs for training (DP/FSDP: model sharded across 4 GPUs)
-#   - Total: 8 GPUs
+#   - 2 GPUs for inference (2 inference GPUs total, TP=1 per engine)
+#   - 2 GPUs for training (DP/FSDP across 2 GPUs)
+#   - Total: 4 GPUs
 #
 # Installation:
 #   pip install -e ".[vllm]"  # Install vLLM backend

--- a/configs/vllm_qwen3_5_35b.yaml
+++ b/configs/vllm_qwen3_5_35b.yaml
@@ -9,7 +9,7 @@
 #   pip install -e ".[vllm]"  # Install vLLM backend
 #
 # Usage:
-#   python -m torchspec.train_entry --config configs/vllm_qwen3_35b.yaml
+#   python -m torchspec.train_entry --config configs/vllm_qwen3_5_35b.yaml
 #
 # Note: Uses vLLM's extract_hidden_states speculative method with MooncakeHiddenStatesConnector.
 

--- a/patches/vllm/v0.19.0/hybrid_kv_cache.patch
+++ b/patches/vllm/v0.19.0/hybrid_kv_cache.patch
@@ -1,5 +1,72 @@
---- a/vllm/v1/core/kv_cache_utils.py	2026-04-09 08:45:04.525155907 +0000
-+++ b/vllm/v1/core/kv_cache_utils.py	2026-04-09 02:50:54.699304331 +0000
+Hybrid KV cache + SupportsHMA patches for vLLM 0.19
+
+Superseded by: https://github.com/vllm-project/vllm/pulls?q=is%3Aopen+is%3Apr+kv_offload%2BHMA
+Once the kv_offload+HMA series lands (PRs #36644, #36645, #37885, #38261,
+#38453, #39401–#39403), this patch is no longer needed.
+
+1. vllm/config/vllm.py — Check supports_hma() on connector class before
+   auto-disabling HMA when kv_transfer_config is set (backport of PR #36636).
+
+2. vllm/v1/core/kv_cache_utils.py — Handle heterogeneous page sizes
+   (e.g. FullAttention + Mamba/GDN) in KV cache allocation, grouping,
+   and memory estimation.
+
+3. vllm/v1/spec_decode/extract_hidden_states.py — Use per-layer slot_mappings
+   for CacheOnly during propose.  On hybrid models the CacheOnly layer is in
+   a separate KV group; common_attn_metadata.slot_mapping belongs to the
+   attention group and has wrong block_size / block IDs.
+
+Apply:
+  cd /usr/local/lib/python3.12/dist-packages && patch -p1 < /path/to/hybrid_kv_cache.patch
+
+--- a/vllm/config/vllm.py
++++ b/vllm/config/vllm.py
+@@ -1251,18 +1251,32 @@
+         if self.scheduler_config.disable_hybrid_kv_cache_manager is None:
+             # Default to disable HMA, but only if the user didn't express a preference.
+             if self.kv_transfer_config is not None:
+-                # NOTE(Kuntai): turn HMA off for connector unless specifically enabled.
+-                need_disable_hybrid_kv_cache_manager = True
+-                logger.warning(
+-                    "Turning off hybrid kv cache manager because "
+-                    "`--kv-transfer-config` is set. This will reduce the "
+-                    "performance of vLLM on LLMs with sliding window attention "
+-                    "or Mamba attention. If you are a developer of kv connector"
+-                    ", please consider supporting hybrid kv cache manager for "
+-                    "your connector by making sure your connector is a subclass"
+-                    " of `SupportsHMA` defined in kv_connector/v1/base.py and"
+-                    " use --no-disable-hybrid-kv-cache-manager to start vLLM."
++                from vllm.distributed.kv_transfer.kv_connector.v1.base import (
++                    supports_hma as _supports_hma,
+                 )
++                from vllm.distributed.kv_transfer.kv_connector.factory import (
++                    KVConnectorFactory,
++                )
++                connector_cls = KVConnectorFactory.get_connector_class(
++                    self.kv_transfer_config)
++                if _supports_hma(connector_cls):
++                    logger.info(
++                        "Connector %s supports HMA; keeping hybrid kv cache "
++                        "manager enabled.", connector_cls.__name__,
++                    )
++                else:
++                    need_disable_hybrid_kv_cache_manager = True
++                    logger.warning(
++                        "Turning off hybrid kv cache manager because "
++                        "`--kv-transfer-config` is set. This will reduce the "
++                        "performance of vLLM on LLMs with sliding window "
++                        "attention or Mamba attention. If you are a developer "
++                        "of kv connector, please consider supporting hybrid kv"
++                        " cache manager for your connector by making sure your"
++                        " connector is a subclass of `SupportsHMA` defined in "
++                        "kv_connector/v1/base.py and use "
++                        "--no-disable-hybrid-kv-cache-manager to start vLLM."
++                    )
+             self.scheduler_config.disable_hybrid_kv_cache_manager = (
+                 need_disable_hybrid_kv_cache_manager
+             )
+--- a/vllm/v1/core/kv_cache_utils.py
++++ b/vllm/v1/core/kv_cache_utils.py
 @@ -1123,32 +1123,58 @@
              for layer_name in kv_cache_groups[0].layer_names
          ]
@@ -132,3 +199,33 @@
      # General case: group_size pools, each shared by one layer per group
      # Memory = group_size * page_size * blocks_for_max_len
      group_size = max(len(group.layer_names) for group in kv_cache_groups)
+--- a/vllm/v1/spec_decode/extract_hidden_states.py
++++ b/vllm/v1/spec_decode/extract_hidden_states.py
+@@ -131,11 +131,24 @@
+         if num_tokens_across_dp is not None:
+             num_tokens_across_dp[self.dp_rank] = num_input_tokens
+ 
++        cache_only_slot_mapping = None
++        if slot_mappings is not None:
++            if isinstance(slot_mappings, dict):
++                cache_only_slot_mapping = next(
++                    (v for k, v in slot_mappings.items()
++                     if "cache_only" in k), None)
++            elif isinstance(slot_mappings, list) and slot_mappings:
++                cache_only_slot_mapping = next(
++                    (v for k, v in slot_mappings[0].items()
++                     if "cache_only" in k), None)
++        if cache_only_slot_mapping is None:
++            cache_only_slot_mapping = common_attn_metadata.slot_mapping
++
+         with set_forward_context(
+             per_layer_attn_metadata,
+             self.vllm_config,
+             num_tokens=num_input_tokens,
+             num_tokens_across_dp=num_tokens_across_dp,
+             cudagraph_runtime_mode=cudagraph_runtime_mode,
+             slot_mapping=self._get_slot_mapping(
+-                num_input_tokens, common_attn_metadata.slot_mapping
++                num_input_tokens, cache_only_slot_mapping
+             ),
+         ):

--- a/tests/test_connector_slot_mapping.py
+++ b/tests/test_connector_slot_mapping.py
@@ -1,0 +1,159 @@
+"""Unit tests for slot-mapping and chunked prefill in MooncakeHiddenStatesConnector.
+
+Tests _slot_mapping_from_block_ids (the sole slot-mapping strategy, matching
+upstream's design of always computing from block_ids) and _extract_from_kv_cache.
+"""
+
+import pytest
+import torch
+
+from torchspec.inference.engine.mooncake_hidden_states_connector import (
+    _extract_from_kv_cache,
+    _slot_mapping_from_block_ids,
+)
+
+
+class TestSlotMappingFromBlockIds:
+    def test_single_block(self):
+        result = _slot_mapping_from_block_ids(
+            block_ids=[5],
+            page_size=4,
+            num_tokens=4,
+            device=torch.device("cpu"),
+        )
+        expected = torch.tensor([20, 21, 22, 23], dtype=torch.int64)
+        assert torch.equal(result, expected)
+
+    def test_multiple_blocks(self):
+        result = _slot_mapping_from_block_ids(
+            block_ids=[2, 7],
+            page_size=3,
+            num_tokens=6,
+            device=torch.device("cpu"),
+        )
+        expected = torch.tensor([6, 7, 8, 21, 22, 23], dtype=torch.int64)
+        assert torch.equal(result, expected)
+
+    def test_partial_last_block(self):
+        result = _slot_mapping_from_block_ids(
+            block_ids=[0, 1],
+            page_size=4,
+            num_tokens=5,
+            device=torch.device("cpu"),
+        )
+        expected = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64)
+        assert torch.equal(result, expected)
+
+    def test_non_contiguous_blocks(self):
+        result = _slot_mapping_from_block_ids(
+            block_ids=[10, 3],
+            page_size=2,
+            num_tokens=4,
+            device=torch.device("cpu"),
+        )
+        expected = torch.tensor([20, 21, 6, 7], dtype=torch.int64)
+        assert torch.equal(result, expected)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_gpu_device(self):
+        result = _slot_mapping_from_block_ids(
+            block_ids=[1, 2],
+            page_size=3,
+            num_tokens=5,
+            device=torch.device("cuda:0"),
+        )
+        assert result.device.type == "cuda"
+        expected = torch.tensor([3, 4, 5, 6, 7], dtype=torch.int64, device="cuda:0")
+        assert torch.equal(result, expected)
+
+    def test_chunked_prefill_partial_skip(self):
+        """With fewer blocks than needed, num_slots < num_tokens — the
+        chunked prefill guard in save_kv_layer should skip this request."""
+        block_ids = [0, 1]
+        page_size = 16
+        num_tokens = 200
+        slot_mapping = _slot_mapping_from_block_ids(
+            block_ids,
+            page_size,
+            num_tokens,
+            device=torch.device("cpu"),
+        )
+        assert slot_mapping.shape[0] < num_tokens
+
+    def test_chunked_prefill_full_store(self):
+        """With enough blocks, num_slots >= num_tokens — store proceeds."""
+        block_ids = list(range(13))
+        page_size = 16
+        num_tokens = 200
+        slot_mapping = _slot_mapping_from_block_ids(
+            block_ids,
+            page_size,
+            num_tokens,
+            device=torch.device("cpu"),
+        )
+        assert slot_mapping.shape[0] >= num_tokens
+
+    def test_hma_page_size_vs_block_size(self):
+        """On HMA models, page_size (from tensor shape) differs from
+        cache_config.block_size.  Using the tensor's page_size produces
+        indices within the KV cache's flat size."""
+        block_ids = [3, 7]
+        actual_page_size = 16
+        wrong_block_size = 1056
+        num_tokens = 20
+
+        correct = _slot_mapping_from_block_ids(
+            block_ids,
+            actual_page_size,
+            num_tokens,
+            device=torch.device("cpu"),
+        )
+        assert correct.max().item() < 200
+
+        wrong = _slot_mapping_from_block_ids(
+            block_ids,
+            wrong_block_size,
+            num_tokens,
+            device=torch.device("cpu"),
+        )
+        assert wrong.max().item() > 3000
+
+
+class TestExtractFromKvCache:
+    def test_basic_extraction(self):
+        num_pages, page_size, num_heads, head_size = 4, 3, 2, 4
+        kv_cache = torch.arange(num_pages * page_size * num_heads * head_size, dtype=torch.float32)
+        kv_cache = kv_cache.view(num_pages, page_size, num_heads, head_size)
+
+        slot_mapping = torch.tensor([0, 1, 5], dtype=torch.int64)
+        result = _extract_from_kv_cache(kv_cache, slot_mapping, num_tokens=3)
+
+        flat = kv_cache.flatten(0, 1)
+        expected = flat[slot_mapping][:3]
+        assert torch.equal(result, expected)
+
+    def test_with_block_ids_mapping(self):
+        """End-to-end: block_ids -> slot_mapping -> extract."""
+        num_pages, page_size, num_heads, head_size = 10, 4, 2, 8
+        kv_cache = torch.randn(num_pages, page_size, num_heads, head_size)
+
+        block_ids = [3, 7]
+        num_tokens = 6
+        slot_mapping = _slot_mapping_from_block_ids(
+            block_ids,
+            page_size,
+            num_tokens,
+            device=torch.device("cpu"),
+        )
+        result = _extract_from_kv_cache(kv_cache, slot_mapping, num_tokens)
+        assert result.shape == (num_tokens, num_heads, head_size)
+
+        flat = kv_cache.flatten(0, 1)
+        assert torch.equal(result[0], flat[3 * 4 + 0])
+        assert torch.equal(result[3], flat[3 * 4 + 3])
+        assert torch.equal(result[4], flat[7 * 4 + 0])
+        assert torch.equal(result[5], flat[7 * 4 + 1])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_vllm_engine_integration.py
+++ b/tests/test_vllm_engine_integration.py
@@ -1,67 +1,93 @@
-"""Integration test for vLLM extract_hidden_states with Qwen2.5-VL.
+"""Integration test for vLLM extract_hidden_states + MooncakeHiddenStatesConnector.
 
-Uses a single VLM engine for all tests:
-  1. Text-only via prompt_token_ids
-  2. Text-only formatted_prompts (defer tokenization)
-  3. Multimodal samples from sample_kimi_k25_conversations.jsonl
-     with real image fetching, multi_modal_data, vision token expansion,
-     and loss mask verification
+Uses the same engine setup as VllmEngine: speculative_config with
+extract_hidden_states method, and kv_transfer_config pointing to
+MooncakeHiddenStatesConnector.
 
-Requires: 2+ GPUs, vLLM >= 0.18 (with PR #38987 fix for VLM configs).
+Dumps all tensors to local .pt files for cross-engine comparison (e.g. vs sglang).
+
+Tests:
+  1. Short sequences via prompt_token_ids
+  2. Longer sequences via prompt_token_ids
+  3. Text prompts (defer tokenization path)
 
 Usage:
-    CUDA_VISIBLE_DEVICES=0,1 python tests/test_vllm_engine_integration.py
+  # Start mooncake master first:
+  #   mooncake_master --port 50051 &
+  #   etcd --listen-client-urls http://0.0.0.0:8090 --advertise-client-urls http://localhost:8090 &
+  #
+  python tests/test_vllm_engine_integration.py [--model MODEL] [--tp TP] [--dump-dir DIR]
 """
 
-import json
+import argparse
 import os
-import re
-import sys
-
-os.environ["TOKENIZERS_PARALLELISM"] = "false"
+import socket
+from pathlib import Path
 
 import torch
-from transformers import AutoProcessor, AutoTokenizer
+from transformers import AutoConfig
+
+# ---------------------------------------------------------------------------
+# Mooncake env setup (must happen before any vLLM import)
+# ---------------------------------------------------------------------------
+try:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    LOCAL_IP = s.getsockname()[0]
+    s.close()
+except Exception:
+    LOCAL_IP = "localhost"
+
+os.environ.setdefault("MOONCAKE_MASTER_HOST", LOCAL_IP)
+os.environ.setdefault("MOONCAKE_MASTER_PORT", "51135")
+os.environ.setdefault("MOONCAKE_METADATA_PORT", "8763")
+os.environ.setdefault("MOONCAKE_LOCAL_HOSTNAME", LOCAL_IP)
+os.environ.setdefault("MOONCAKE_MASTER_SERVER", f"{LOCAL_IP}:51135")
 
 
-def main():
-    from vllm import LLM, SamplingParams
+def get_aux_layer_ids(model_path: str) -> list[int]:
+    """Replicate VllmEngine's aux layer resolution: default Eagle3 layers + final layer."""
+    cfg = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    cfg = getattr(cfg, "text_config", cfg)
+    num_layers = cfg.num_hidden_layers
+    # Default Eagle3 aux layers
+    aux_ids = [1, num_layers // 2 - 1, num_layers - 4]
+    # VllmEngine appends the final layer for last_hidden_states capture
+    final_layer = num_layers - 1
+    if final_layer not in aux_ids:
+        aux_ids.append(final_layer)
+    return aux_ids, cfg.hidden_size, num_layers
 
-    model_path = "Qwen/Qwen2.5-VL-7B-Instruct"
-    tp_size = 2
-    aux_layer_ids = [2, 4, 6]
-    hidden_size = 3584
 
-    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
-    processor = AutoProcessor.from_pretrained(model_path, trust_remote_code=True)
+def create_engine(
+    model_path: str,
+    tp_size: int,
+    aux_layer_ids: list[int],
+    max_num_batched_tokens: int | None = None,
+):
+    from vllm import LLM
 
-    print(f"{'=' * 60}")
-    print("vLLM extract_hidden_states Integration Test (VLM)")
-    print(f"{'=' * 60}")
-    print(f"Model:      {model_path}")
-    print(f"TP size:    {tp_size}")
-    print(f"Aux layers: {aux_layer_ids}")
-    print(f"Hidden:     {hidden_size}")
-    print(f"{'=' * 60}", flush=True)
+    extra_args = {}
+    if max_num_batched_tokens is not None:
+        extra_args["max_num_batched_tokens"] = max_num_batched_tokens
+        extra_args["enable_chunked_prefill"] = True
 
-    print("\n[init] Creating LLM with extract_hidden_states...", flush=True)
     engine = LLM(
         model=model_path,
         tensor_parallel_size=tp_size,
-        gpu_memory_utilization=0.5,
+        gpu_memory_utilization=0.7,
         trust_remote_code=True,
         distributed_executor_backend="mp",
         disable_custom_all_reduce=True,
-        max_model_len=4096,
+        disable_log_stats=True,
         enable_prefix_caching=False,
-        enforce_eager=True,
-        limit_mm_per_prompt={"image": 4},
+        max_model_len=4096,
         speculative_config={
             "method": "extract_hidden_states",
             "num_speculative_tokens": 1,
             "draft_model_config": {
                 "hf_config": {
-                    "eagle_aux_hidden_state_layer_ids": aux_layer_ids,
+                    "eagle_aux_hidden_state_layer_ids": list(aux_layer_ids),
                 }
             },
         },
@@ -72,242 +98,291 @@ def main():
             ),
             "kv_role": "kv_producer",
         },
+        compilation_config={"cudagraph_mode": "NONE"},
+        **extra_args,
     )
-    print("      Engine created.", flush=True)
+    return engine
+
+
+def fetch_and_dump(
+    mooncake_store,
+    key: str,
+    seq_len: int,
+    hidden_dim: int,
+    last_hidden_dim: int,
+    dump_dir: Path,
+    label: str,
+) -> dict[str, torch.Tensor]:
+    """Retrieve tensors from mooncake, verify shapes, save to disk."""
+    shapes = {
+        "hidden_states": (seq_len, hidden_dim),
+        "input_ids": (seq_len,),
+        "last_hidden_states": (seq_len, last_hidden_dim),
+    }
+    dtypes = {
+        "hidden_states": torch.bfloat16,
+        "input_ids": torch.long,
+        "last_hidden_states": torch.bfloat16,
+    }
+    data = mooncake_store.get(key, shapes=shapes, dtypes=dtypes, device="cuda")
+
+    tensors = {
+        "hidden_states": data.hidden_states.cpu(),
+        "input_ids": data.input_ids.cpu(),
+        "last_hidden_states": data.last_hidden_states.cpu(),
+    }
+
+    assert tensors["hidden_states"].shape == (seq_len, hidden_dim), (
+        f"hidden_states shape {tensors['hidden_states'].shape} != expected {(seq_len, hidden_dim)}"
+    )
+    assert tensors["input_ids"].shape == (seq_len,)
+    assert tensors["last_hidden_states"].shape == (seq_len, last_hidden_dim)
+
+    dump_path = dump_dir / f"vllm_{label}.pt"
+    torch.save(tensors, dump_path)
+    print(f"  Saved: {dump_path}")
+    print(
+        f"    hidden_states:      {tensors['hidden_states'].shape}, dtype={tensors['hidden_states'].dtype}"
+    )
+    print(
+        f"    input_ids:          {tensors['input_ids'].shape}, first_10={tensors['input_ids'][:10].tolist()}"
+    )
+    print(
+        f"    last_hidden_states: {tensors['last_hidden_states'].shape}, dtype={tensors['last_hidden_states'].dtype}"
+    )
+
+    hs = tensors["hidden_states"].float()
+    lhs = tensors["last_hidden_states"].float()
+    print(f"    hidden_states      norm={hs.norm():.4f}, mean={hs.mean():.6f}, std={hs.std():.6f}")
+    print(
+        f"    last_hidden_states norm={lhs.norm():.4f}, mean={lhs.mean():.6f}, std={lhs.std():.6f}"
+    )
+
+    return tensors
+
+
+def run_test(
+    engine,
+    mooncake_store,
+    prompts,
+    data_ids: list[str],
+    expected_seq_lens: list[int] | None,
+    hidden_dim: int,
+    last_hidden_dim: int,
+    dump_dir: Path,
+    test_name: str,
+):
+    from vllm import SamplingParams
 
     sampling_params = SamplingParams(max_tokens=1, temperature=0)
 
-    # =========================================================================
-    # Test 1: Text-only via prompt_token_ids
-    # =========================================================================
-    print("\n" + "=" * 60)
-    print("TEST 1: Text-only via prompt_token_ids")
-    print("=" * 60)
+    print(f"\n{'=' * 60}")
+    print(f"TEST: {test_name}")
+    print(f"{'=' * 60}")
 
-    prompts = [
-        {"prompt_token_ids": [1, 2345, 6789, 101, 202]},
-        {"prompt_token_ids": [100, 200, 300, 400]},
-    ]
     outputs = engine.generate(prompts, sampling_params, use_tqdm=False)
-    assert len(outputs) == 2
 
     for i, output in enumerate(outputs):
-        kv = getattr(output, "kv_transfer_params", None)
-        print(
-            f"  Output {i}: {len(output.prompt_token_ids)} tokens, "
-            f"kv_params={'present' if kv else 'None'}"
-        )
-        if kv:
-            print(f"    mooncake_key={kv.get('mooncake_key')}")
-            print(f"    input_ids_list[:5]={kv.get('input_ids_list', [])[:5]}")
-    print("✓ Test 1 passed")
+        kv_params = getattr(output, "kv_transfer_params", None)
+        seq_len = len(output.prompt_token_ids)
 
-    # =========================================================================
-    # Test 2: Text-only formatted_prompts (defer tokenization)
-    # =========================================================================
-    print("\n" + "=" * 60)
-    print("TEST 2: Text-only formatted_prompts (defer tokenization)")
-    print("=" * 60)
-
-    text_prompts = ["Hello, world!", "The quick brown fox jumps over the lazy dog."]
-    outputs = engine.generate(text_prompts, sampling_params, use_tqdm=False)
-    assert len(outputs) == 2
-
-    for i, output in enumerate(outputs):
-        kv = getattr(output, "kv_transfer_params", None)
-        token_ids = list(output.prompt_token_ids)
-        decoded = tokenizer.decode(token_ids, skip_special_tokens=True)
-        print(f"  Output {i}: {len(token_ids)} tokens, decoded='{decoded[:60]}...'")
-        if kv and kv.get("input_ids_list"):
-            assert kv["input_ids_list"] == token_ids, (
-                "input_ids_list from kv_params doesn't match prompt_token_ids"
+        if expected_seq_lens is not None:
+            assert seq_len == expected_seq_lens[i], (
+                f"seq_len mismatch: got {seq_len}, expected {expected_seq_lens[i]}"
             )
-            print("    input_ids_list matches prompt_token_ids ✓")
-    print("✓ Test 2 passed")
 
-    # =========================================================================
-    # Test 3: Multimodal samples with real images
-    # =========================================================================
-    print("\n" + "=" * 60)
-    print("TEST 3: Multimodal (real images + defer tokenization + loss mask)")
-    print("=" * 60)
-
-    from vllm.multimodal.utils import fetch_image
-
-    from torchspec.data.template import TEMPLATE_REGISTRY
-    from torchspec.data.utils import extract_media_urls
-    from torchspec.models.ops.loss_mask import compute_assistant_loss_mask
-
-    kimi_path = os.path.join(
-        os.path.dirname(__file__),
-        "..",
-        "examples",
-        "data",
-        "sample_kimi_k25_conversations.jsonl",
-    )
-    samples = []
-    with open(kimi_path) as f:
-        for line in f:
-            line = line.strip()
-            if line:
-                samples.append(json.loads(line))
-    print(f"  Loaded {len(samples)} samples")
-
-    # -- 3a: Build prompt dicts with multi_modal_data --
-    mm_data_ids = []
-    mm_prompts = []
-    mm_multimodal_inputs = []
-
-    for sample in samples:
-        sid = sample["id"]
-        messages = list(sample["conversations"])
-        multimodal_inputs = extract_media_urls(messages)
-
-        formatted = processor.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=False
-        )
-
-        prompt_dict = {"prompt": formatted}
-        if multimodal_inputs and multimodal_inputs.get("images"):
-            image_urls = multimodal_inputs["images"]
-            loaded_images = [fetch_image(url) for url in image_urls]
-            prompt_dict["multi_modal_data"] = {
-                "image": loaded_images[0] if len(loaded_images) == 1 else loaded_images
-            }
-
-        mm_data_ids.append(sid)
-        mm_prompts.append(prompt_dict)
-        mm_multimodal_inputs.append(multimodal_inputs)
-
-        has_mm = "multi_modal_data" in prompt_dict
-        print(f"  {sid}: multimodal={has_mm}")
-
-    assert "multi_modal_data" not in mm_prompts[0], "text-only should have no mm"
-    assert "multi_modal_data" in mm_prompts[3], "kimi_mm_001 should have mm"
-
-    # -- 3b: Run through engine --
-    print("\n  Running engine.generate()...", flush=True)
-    outputs = engine.generate(mm_prompts, sampling_params, use_tqdm=False)
-    assert len(outputs) == len(samples)
-
-    sample_by_id = {s["id"]: s for s in samples}
-
-    for i, output in enumerate(outputs):
-        did = mm_data_ids[i]
-        token_ids = list(output.prompt_token_ids)
-        kv = getattr(output, "kv_transfer_params", None)
-        has_mm = mm_multimodal_inputs[i] is not None
-        print(
-            f"  {did}: {len(token_ids)} tokens, multimodal={has_mm}, "
-            f"kv_params={'present' if kv else 'None'}"
-        )
-
-    # -- 3c: Verify vision tokens in multimodal outputs --
-    vision_start_text = "<|vision_start|>"
-    print("\n  Checking for vision placeholders...")
-
-    for i, (did, output) in enumerate(zip(mm_data_ids, outputs)):
-        mm_input = mm_multimodal_inputs[i]
-        if mm_input is None:
+        if kv_params is None:
+            print(f"  WARNING: Request {data_ids[i]}: no kv_transfer_params!")
             continue
-        num_images = len(mm_input.get("images") or [])
-        token_ids = list(output.prompt_token_ids)
-        decoded = tokenizer.decode(token_ids, skip_special_tokens=False)
-        count = decoded.count(vision_start_text)
-        assert count == num_images, f"{did}: expected {num_images} vision block(s), found {count}"
-        # Vision tokens expand the sequence beyond the text template
-        text_template_len = len(tokenizer.encode(mm_prompts[i]["prompt"], add_special_tokens=False))
-        assert len(token_ids) > text_template_len, (
-            f"{did}: vision-expanded ({len(token_ids)}) should exceed "
-            f"text template ({text_template_len})"
+
+        mooncake_key = kv_params.get("mooncake_key", data_ids[i])
+        print(f"\n  Request {data_ids[i]}: seq_len={seq_len}, mooncake_key={mooncake_key}")
+
+        label = f"{test_name}_{data_ids[i]}"
+        fetch_and_dump(
+            mooncake_store,
+            mooncake_key,
+            seq_len,
+            hidden_dim,
+            last_hidden_dim,
+            dump_dir,
+            label,
         )
-        print(
-            f"  {did}: {count} vision block(s), "
-            f"{len(token_ids)} tokens (template={text_template_len}) ✓"
-        )
 
-    # -- 3d: Verify loss mask recovers last-turn assistant response --
-    def _normalize(s: str) -> str:
-        s = re.sub(r"(</?think>)", r" \1 ", s)
-        return re.sub(r"\s+", " ", s).strip()
+    print(f"\n✓ {test_name} passed")
 
-    def _visible_content(s: str) -> str:
-        return re.sub(r"<think>.*?</think>", "", s, flags=re.DOTALL).strip()
 
-    qwen_template = TEMPLATE_REGISTRY.get("qwen2-vl")
-    header_text = qwen_template.assistant_header.rstrip("\n")
-    full_header_ids = tokenizer.encode(qwen_template.assistant_header, add_special_tokens=False)
-    stripped_header_ids = tokenizer.encode(header_text, add_special_tokens=False)
-    skip_after_header = len(full_header_ids) - len(stripped_header_ids)
-    end_token_ids = tokenizer.encode(qwen_template.end_of_turn_token, add_special_tokens=False)
-    print(
-        f"\n  Loss mask: header={stripped_header_ids}, end={end_token_ids}, "
-        f"skip_after={skip_after_header}"
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="Qwen/Qwen3-8B")
+    parser.add_argument("--tp", type=int, default=4)
+    parser.add_argument("--dump-dir", default="./tensor_dumps")
+    parser.add_argument(
+        "--aux-layers",
+        type=int,
+        nargs="*",
+        default=None,
+        help="Override aux layer IDs (without final layer; it is auto-appended)",
+    )
+    args = parser.parse_args()
+
+    dump_dir = Path(args.dump_dir)
+    dump_dir.mkdir(parents=True, exist_ok=True)
+
+    # Resolve aux layers
+    auto_aux_ids, hidden_size, num_layers = get_aux_layer_ids(args.model)
+    if args.aux_layers is not None:
+        aux_layer_ids = list(args.aux_layers)
+        final_layer = num_layers - 1
+        if final_layer not in aux_layer_ids:
+            aux_layer_ids.append(final_layer)
+    else:
+        aux_layer_ids = auto_aux_ids
+
+    num_training_layers = len(aux_layer_ids) - 1  # last is final-layer for last_hidden_states
+    hidden_dim = num_training_layers * hidden_size
+    last_hidden_dim = hidden_size
+
+    print(f"Model:           {args.model}")
+    print(f"TP size:         {args.tp}")
+    print(f"Aux layer IDs:   {aux_layer_ids}")
+    print(f"  training layers: {aux_layer_ids[:-1]} -> hidden_dim={hidden_dim}")
+    print(f"  final layer:     {aux_layer_ids[-1]} -> last_hidden_dim={last_hidden_dim}")
+    print(f"Hidden size:     {hidden_size}")
+    print(f"Num layers:      {num_layers}")
+    print(f"Dump dir:        {dump_dir}")
+
+    # Save test metadata for comparison script
+    meta = {
+        "engine": "vllm",
+        "model": args.model,
+        "aux_layer_ids": aux_layer_ids,
+        "num_training_layers": num_training_layers,
+        "hidden_size": hidden_size,
+        "last_hidden_dim": last_hidden_dim,
+    }
+    torch.save(meta, dump_dir / "vllm_meta.pt")
+
+    engine = create_engine(args.model, args.tp, aux_layer_ids)
+
+    from torchspec.transfer.mooncake import EagleMooncakeStore, MooncakeConfig
+
+    mooncake_config = MooncakeConfig.from_env()
+    mooncake_store = EagleMooncakeStore(mooncake_config)
+    mooncake_store.setup(device="cuda")
+
+    # ── Test 1: Short sequences (raw token IDs) ──────────────────────────
+    input_ids_list = [
+        [1, 2345, 6789],
+        [100, 200, 300, 400],
+        [500, 600],
+    ]
+    data_ids = ["short_0", "short_1", "short_2"]
+    prompts = [{"prompt_token_ids": ids} for ids in input_ids_list]
+    seq_lens = [len(ids) for ids in input_ids_list]
+
+    run_test(
+        engine,
+        mooncake_store,
+        prompts,
+        data_ids,
+        seq_lens,
+        hidden_dim,
+        last_hidden_dim,
+        dump_dir,
+        "short_seqs",
     )
 
-    for i, (did, output) in enumerate(zip(mm_data_ids, outputs)):
-        token_ids_tensor = torch.tensor(list(output.prompt_token_ids))
-        mask = compute_assistant_loss_mask(
-            token_ids_tensor,
-            stripped_header_ids,
-            end_token_ids,
-            last_turn_only=True,
-            skip_after_header=skip_after_header,
-        )
-        masked_ids = token_ids_tensor[mask.bool()].tolist()
-        recovered_text = tokenizer.decode(masked_ids, skip_special_tokens=False)
+    # ── Test 2: Longer sequences (raw token IDs) ─────────────────────────
+    long_input_ids = [
+        list(range(1, 101)),
+        list(range(200, 351)),
+        list(range(400, 465)),
+    ]
+    long_data_ids = ["long_0", "long_1", "long_2"]
+    prompts = [{"prompt_token_ids": ids} for ids in long_input_ids]
+    long_seq_lens = [len(ids) for ids in long_input_ids]
 
-        conv = sample_by_id[did]["conversations"]
-        last_assistant_content = None
-        for msg in conv:
-            if msg.get("role") == "assistant":
-                content = msg.get("content", "")
-                if isinstance(content, str):
-                    last_assistant_content = content
-
-        assert mask.sum().item() > 0, f"{did}: loss mask is all zeros"
-
-        recovered_norm = _normalize(recovered_text)
-        visible = _visible_content(last_assistant_content)
-        assert visible, f"{did}: last assistant turn has no visible content"
-        visible_norm = _normalize(visible)
-        assert visible_norm in recovered_norm, (
-            f"{did}: last assistant content not found in loss-masked region.\n"
-            f"  Expected: {visible_norm[:100]}...\n"
-            f"  Recovered: {recovered_norm[:200]}..."
-        )
-
-        all_assistant = [
-            msg.get("content", "")
-            for msg in conv
-            if msg.get("role") == "assistant" and isinstance(msg.get("content", ""), str)
-        ]
-        if len(all_assistant) > 1:
-            earlier_visible = _visible_content(all_assistant[0])
-            if earlier_visible:
-                earlier_norm = _normalize(earlier_visible)
-                assert earlier_norm not in recovered_norm, (
-                    f"{did}: earlier turn should NOT be in loss mask: {earlier_norm[:80]}"
-                )
-            print(f"  {did}: {mask.sum().item()} masked tokens, last-turn only ✓")
-        else:
-            print(f"  {did}: {mask.sum().item()} masked tokens, content matched ✓")
-
-    # -- 3e: Sequence length checks --
-    lens = {mm_data_ids[i]: len(outputs[i].prompt_token_ids) for i in range(len(outputs))}
-    assert lens["kimi_mm_003"] > lens["kimi_mm_001"], (
-        f"Two-image ({lens['kimi_mm_003']}) should exceed single-image ({lens['kimi_mm_001']})"
+    run_test(
+        engine,
+        mooncake_store,
+        prompts,
+        long_data_ids,
+        long_seq_lens,
+        hidden_dim,
+        last_hidden_dim,
+        dump_dir,
+        "long_seqs",
     )
-    print(f"\n  kimi_mm_001={lens['kimi_mm_001']} < kimi_mm_003={lens['kimi_mm_003']} ✓")
 
-    print("\n✓ Test 3 passed")
+    # ── Test 3: Text prompts (defer tokenization) ────────────────────────
+    text_prompts = [
+        "Hello, world!",
+        "The quick brown fox jumps over the lazy dog.",
+        "Once upon a time in a land far away, there lived a brave knight.",
+    ]
+    prompt_data_ids = ["prompt_0", "prompt_1", "prompt_2"]
 
-    # =========================================================================
+    run_test(
+        engine,
+        mooncake_store,
+        text_prompts,
+        prompt_data_ids,
+        None,
+        hidden_dim,
+        last_hidden_dim,
+        dump_dir,
+        "text_prompts",
+    )
+
+    # ── Test 4: Chunked prefill ─────────────────────────────────────────
+    # Destroy the first engine and create one with a small token budget
+    # so sequences are split across multiple scheduler steps.
+    del engine
+
+    print(f"\n{'=' * 60}")
+    print("Creating chunked-prefill engine (max_num_batched_tokens=128)")
+    print(f"{'=' * 60}")
+
+    chunked_engine = create_engine(
+        args.model,
+        args.tp,
+        aux_layer_ids,
+        max_num_batched_tokens=128,
+    )
+
+    # Sequences longer than 128 tokens will require multiple prefill chunks.
+    chunked_input_ids = [
+        list(range(1, 201)),  # 200 tokens → 2 chunks
+        list(range(300, 700)),  # 400 tokens → 4 chunks
+    ]
+    chunked_data_ids = ["chunked_0", "chunked_1"]
+    prompts = [{"prompt_token_ids": ids} for ids in chunked_input_ids]
+    chunked_seq_lens = [len(ids) for ids in chunked_input_ids]
+
+    run_test(
+        chunked_engine,
+        mooncake_store,
+        prompts,
+        chunked_data_ids,
+        chunked_seq_lens,
+        hidden_dim,
+        last_hidden_dim,
+        dump_dir,
+        "chunked_prefill",
+    )
+
+    del chunked_engine
+
+    # ── Summary ──────────────────────────────────────────────────────────
     print(f"\n{'=' * 60}")
     print("All tests passed!")
+    print(f"Tensor dumps saved to: {dump_dir}/")
     print(f"{'=' * 60}")
-    del engine
-    sys.exit(0)
+
+    pt_files = sorted(dump_dir.glob("vllm_*.pt"))
+    for f in pt_files:
+        print(f"  {f.name}")
 
 
 if __name__ == "__main__":

--- a/torchspec/inference/engine/mooncake_hidden_states_connector.py
+++ b/torchspec/inference/engine/mooncake_hidden_states_connector.py
@@ -79,36 +79,32 @@ def _extract_from_kv_cache(
     return padded_kv[:num_tokens]
 
 
+def _slot_mapping_from_block_ids(
+    block_ids: list[int],
+    page_size: int,
+    num_tokens: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Compute slot_mapping from accumulated block_ids instead of attn_metadata.
+
+    We cannot use ``attn_metadata.slot_mapping`` for two reasons:
+    1. Chunked prefill: attn_metadata only has the current chunk's slots, but
+       we need the full sequence's mapping (block_ids are accumulated across
+       chunks in ``build_connector_meta``).
+    2. HMA models: ``cache_config.block_size`` differs from the CacheOnly
+       group's actual page_size.  Reading ``page_size`` from
+       ``kv_layer.shape[1]`` handles both cases correctly.
+    """
+    block_ids_gpu = torch.tensor(block_ids, dtype=torch.int64, device=device)
+    offsets = torch.arange(page_size, dtype=torch.int64, device=device)
+    return (block_ids_gpu.unsqueeze(1) * page_size + offsets).flatten()[:num_tokens]
+
+
 @dataclass
 class _ReqMeta:
     req_id: str
     token_ids: torch.Tensor
-    slot_mapping: torch.Tensor
-    new_req: bool
-
-    @staticmethod
-    def make(
-        req_id: str,
-        token_ids: list[int],
-        block_ids: list[int],
-        block_size: int,
-        new_req: bool,
-    ) -> _ReqMeta:
-        token_ids_tensor = torch.tensor(token_ids)
-        block_ids_tensor = torch.tensor(block_ids)
-        num_blocks = block_ids_tensor.shape[0]
-        block_offsets = torch.arange(0, block_size)
-        slot_mapping = (
-            block_offsets.reshape((1, block_size))
-            + block_ids_tensor.reshape((num_blocks, 1)) * block_size
-        )
-        slot_mapping = slot_mapping.flatten()
-        return _ReqMeta(
-            req_id=req_id,
-            token_ids=token_ids_tensor,
-            slot_mapping=slot_mapping,
-            new_req=new_req,
-        )
+    block_ids: list[int] = field(default_factory=list)
 
 
 @dataclass
@@ -120,10 +116,14 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
         req_id: str,
         token_ids: list[int],
         block_ids: list[int],
-        block_size: int,
-        new_req: bool = True,
     ) -> None:
-        self.requests.append(_ReqMeta.make(req_id, token_ids, block_ids, block_size, new_req))
+        self.requests.append(
+            _ReqMeta(
+                req_id=req_id,
+                token_ids=torch.tensor(token_ids),
+                block_ids=list(block_ids),
+            )
+        )
 
 
 class MooncakeHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
@@ -151,6 +151,7 @@ class MooncakeHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         )
         self._block_size = vllm_config.cache_config.block_size
         self.cache_layers: list[str] = []
+        self._cache_layer_group_id: int = self._find_cache_layer_group_id(kv_cache_config)
 
         assert self._vllm_config.speculative_config is not None, (
             "MooncakeHiddenStatesConnector requires 'extract_hidden_states' speculative method"
@@ -170,13 +171,53 @@ class MooncakeHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         self._req_blocks: dict[str, list[int]] = {}
         self._req_metadata: dict[str, dict[str, Any]] = {}
 
-        # Worker-side state: Mooncake store (lazy init)
         self._mooncake_store = None
         self._mooncake_setup_done = False
+        self._tp_rank: int | None = None
+
+    @staticmethod
+    def _find_cache_layer_group_id(kv_cache_config) -> int:
+        """Find the KV cache group that contains the CacheOnlyAttentionLayer.
+
+        When ``kv_cache_config`` is available (worker side), we look for the
+        group whose layer name contains ``cache_only_layers``.  On the
+        scheduler side (``kv_cache_config is None``) we return ``None``
+        and resolve it lazily in ``build_connector_meta`` by picking the
+        group with ``ceil(num_tokens / block_size)`` blocks.
+        """
+        if kv_cache_config is None:
+            return None  # type: ignore[return-value]
+        for gid, group in enumerate(kv_cache_config.kv_cache_groups):
+            for name in group.layer_names:
+                if "cache_only_layers" in name:
+                    logger.info(
+                        f"Cache-only layer found in KV group {gid}: {name} "
+                        f"(total groups={len(kv_cache_config.kv_cache_groups)})"
+                    )
+                    return gid
+        logger.warning(
+            f"Cache-only layer NOT found in KV cache groups "
+            f"(groups={[g.layer_names for g in kv_cache_config.kv_cache_groups]})"
+        )
+        return None  # type: ignore[return-value]
+
+    def _get_tp_rank(self) -> int:
+        if self._tp_rank is None:
+            try:
+                from vllm.distributed import get_tensor_model_parallel_rank
+
+                self._tp_rank = get_tensor_model_parallel_rank()
+            except Exception:
+                self._tp_rank = 0
+        return self._tp_rank
 
     def _ensure_mooncake_store(self) -> bool:
         if self._mooncake_setup_done:
             return self._mooncake_store is not None
+
+        if self._get_tp_rank() != 0:
+            self._mooncake_setup_done = True
+            return False
 
         if not os.environ.get("MOONCAKE_MASTER_SERVER") and not os.environ.get(
             "MOONCAKE_MASTER_HOST"
@@ -256,20 +297,34 @@ class MooncakeHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         assert isinstance(connector_metadata, MooncakeConnectorMetadata)
 
         if not self._ensure_mooncake_store():
-            logger.warning("save_kv_layer: Mooncake store not available, skipping")
+            if self._get_tp_rank() == 0:
+                logger.warning("save_kv_layer: Mooncake store not available, skipping")
             return
+
+        # Use tensor's actual page_size, not cache_config.block_size
+        # (they differ on HMA models).
+        page_size = kv_layer.shape[1]
 
         for request in connector_metadata.requests:
             num_tokens = request.token_ids.shape[0]
-            num_slots = request.slot_mapping.shape[0]
+            mooncake_key = _sanitize_mooncake_key(request.req_id)
+
+            # Recompute from accumulated block_ids — attn_metadata.slot_mapping
+            # only covers the current chunk, not the full sequence.
+            slot_mapping = _slot_mapping_from_block_ids(
+                request.block_ids,
+                page_size,
+                num_tokens,
+                device=kv_layer.device,
+            )
+            num_slots = slot_mapping.shape[0]
 
             # With chunked prefill, save_kv_layer is called per chunk.
-            # Mooncake keys are write-once (can't overwrite), so we skip
-            # partial chunks and only write when all blocks are allocated.
+            # Skip partial chunks — only store when all blocks are allocated.
             if num_slots < num_tokens:
                 continue
 
-            hidden_states_3d = _extract_from_kv_cache(kv_layer, request.slot_mapping, num_tokens)
+            hidden_states_3d = _extract_from_kv_cache(kv_layer, slot_mapping, num_tokens)
 
             all_hidden = hidden_states_3d.reshape(num_tokens, -1)
 
@@ -280,8 +335,6 @@ class MooncakeHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
             last_hidden_states = all_hidden[:, -self._hidden_size :]
 
             input_ids = request.token_ids.to(hidden_states.device)
-
-            mooncake_key = _sanitize_mooncake_key(request.req_id)
 
             try:
                 self._mooncake_store.put(
@@ -316,17 +369,34 @@ class MooncakeHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         meta = MooncakeConnectorMetadata()
         for new_req in scheduler_output.scheduled_new_reqs:
             token_ids = new_req.prompt_token_ids or []
+            group_sizes = [len(g) for g in new_req.block_ids]
+            gid = self._cache_layer_group_id
+            if gid is None:
+                # On the scheduler side kv_cache_config is unavailable, so we
+                # pick the group with the most blocks.  The CacheOnly group
+                # uses the smallest page_size and therefore always has the
+                # highest block count for a given token count.
+                gid = max(range(len(new_req.block_ids)), key=lambda i: len(new_req.block_ids[i]))
+                self._cache_layer_group_id = gid
+                logger.warning(f"Resolved cache-only KV group id={gid} (group_sizes={group_sizes})")
             meta.add_request(
                 new_req.req_id,
                 token_ids=token_ids,
-                block_ids=new_req.block_ids[0],
-                block_size=self._block_size,
+                block_ids=new_req.block_ids[gid],
+            )
+            logger.debug(
+                "build_connector_meta: req_id=%s key=%s num_tokens=%d gid=%d "
+                "group_sizes=%s chosen_blocks=%d",
+                new_req.req_id,
+                _sanitize_mooncake_key(new_req.req_id),
+                len(token_ids),
+                gid,
+                group_sizes,
+                len(new_req.block_ids[gid]),
             )
             self._active_requests[new_req.req_id] = new_req
-            self._req_blocks[new_req.req_id] = list(new_req.block_ids[0])
+            self._req_blocks[new_req.req_id] = list(new_req.block_ids[gid])
 
-            # Pre-compute metadata that request_finished will return.
-            # The mooncake key and shapes are deterministic from the request.
             seq_len = len(token_ids)
             training_hidden_size = self._num_training_layers * self._hidden_size
             mooncake_key = _sanitize_mooncake_key(new_req.req_id)
@@ -358,15 +428,13 @@ class MooncakeHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
             cached_req = self._active_requests[req_id]
             req_block_ids = self._req_blocks[req_id]
 
-            block_ids = new_block_ids[0]
+            block_ids = new_block_ids[self._cache_layer_group_id]
             req_block_ids.extend(block_ids)
 
             meta.add_request(
                 req_id=req_id,
                 token_ids=cached_req.prompt_token_ids or [],
                 block_ids=req_block_ids,
-                block_size=self._block_size,
-                new_req=False,
             )
 
         return meta

--- a/torchspec/inference/engine/vllm_engine.py
+++ b/torchspec/inference/engine/vllm_engine.py
@@ -155,7 +155,12 @@ class VllmEngine(InferenceEngine, RayActor):
         # after layer N runs".  vllm's capture hook fires at the INPUT of each
         # listed layer (= output of the previous layer), so we shift by +1 to
         # align with sglang's convention.
-        self.aux_hidden_state_layer_ids = [lid + 1 for lid in self.aux_hidden_state_layer_ids]
+        # Skip the shift for the final layer — it would overflow to
+        # num_hidden_layers, and the append block below handles it correctly.
+        num_layers = _cfg.num_hidden_layers
+        self.aux_hidden_state_layer_ids = [
+            lid + 1 for lid in self.aux_hidden_state_layer_ids if lid + 1 < num_layers
+        ]
         if self.rank == 0:
             logger.info(
                 f"Shifted aux layer ids +1 for vllm (post-layer → pre-next-layer): "
@@ -346,7 +351,7 @@ class VllmEngine(InferenceEngine, RayActor):
         # 2x safety for PyTorch allocator fragmentation + small extras
         reserved_bytes = int(connector_bytes * 2)
 
-        total_gpu_bytes = torch.cuda.get_device_properties(0).total_memory
+        total_gpu_bytes = torch.cuda.get_device_properties(torch.cuda.current_device()).total_memory
         overhead_frac = reserved_bytes / total_gpu_bytes
         adjusted = base - overhead_frac
         adjusted = max(adjusted, 0.4)

--- a/torchspec/training/eagle3_trainer.py
+++ b/torchspec/training/eagle3_trainer.py
@@ -221,6 +221,31 @@ class Eagle3Trainer(Trainer):
             self.target_lm_head.eval()
             self.target_lm_head.requires_grad_(False)
 
+        # Sync norm status from rank 0 so all ranks have the same parameter count
+        # before the broadcast loop (prevents NCCL deadlock if norm loading
+        # silently failed on rank 0 but structure creation succeeded elsewhere).
+        has_norm = torch.tensor(
+            [self.target_lm_head.norm is not None], dtype=torch.int32, device="cuda"
+        )
+        dist.broadcast(has_norm, src=0)
+        if has_norm.item():
+            if self.target_lm_head.norm is None:
+                logger.warning(
+                    f"[Rank {self.dp_rank}] Rank 0 has norm but this rank does not — "
+                    "this indicates _init_norm_structure failed; attempting recovery"
+                )
+                self.target_lm_head._init_norm_structure()
+                self.target_lm_head.norm = self.target_lm_head.norm.to(
+                    device="cuda", dtype=torch.bfloat16
+                )
+        else:
+            if self.target_lm_head.norm is not None:
+                logger.warning(
+                    f"[Rank {self.dp_rank}] Rank 0 does not have norm — "
+                    "removing norm on this rank to match"
+                )
+                self.target_lm_head.norm = None
+
         dist.barrier()
 
         for param in self.target_lm_head.parameters():


### PR DESCRIPTION
## Summary

- Fix NCCL broadcast deadlock when training on models where TargetLMHead norm loading silently fails on rank 0 (e.g. Qwen3.5-35B-A3B with wrong `norm_key`)
- Fix CUDA index-out-of-bounds crash on HMA (Hybrid Memory Architecture) models where the CacheOnly KV cache group has a different page_size than `cache_config.block_size`
- Fix chunked prefill support: skip partial chunks in `save_kv_layer`, only store when the full sequence's blocks are allocated
- Clean up dead code and fix a latent `TypeError` in the cached_reqs path of `build_connector_meta`
- Add Qwen3.5-35B-A3B vLLM training config
- Add unit tests for slot_mapping and integration tests with chunked prefill coverage

## Test plan

- [x] Unit tests: `python -m pytest tests/test_connector_slot_mapping.py -v` (10 tests)
- [x] Integration test: `python tests/test_vllm_engine_integration.py --model Qwen/Qwen3-8B --tp 1` (4 test suites: short_seqs, long_seqs, text_prompts, chunked_prefill)
- [x] End-to-end training: `examples/qwen3_5-35b-single-node/run.sh` on 4xB200 (2 training + 2 inference GPUs), verified 500+ training steps at ~5 steps/s