### PR TITLE
Add vLLM v0.19.0 compatibility patches

### DIFF
--- a/patches/vllm/v0.19.0/vllm.patch
+++ b/patches/vllm/v0.19.0/vllm.patch
@@ -1,0 +1,88 @@
+TorchSpec patches for vllm v0.19.0
+
+1. Fix flash_attn rotary embedding import with FA4
+   vllm/model_executor/layers/rotary_embedding/common.py
+
+2. Fix extract_hidden_states crash with quantized KV cache dtype
+   vllm/model_executor/models/extract_hidden_states.py
+
+3. Fix extract_hidden_states for VLM models (PR #38987)
+   vllm/transformers_utils/configs/extract_hidden_states.py
+   (already in vllm >= 0.19.0, included here for older versions)
+
+Apply:
+  cd $VLLM_ROOT && git apply /path/to/vllm.patch
+
+--- a/vllm/model_executor/layers/rotary_embedding/common.py
++++ b/vllm/model_executor/layers/rotary_embedding/common.py
+@@ -135,8 +135,11 @@
+ 
+         self.apply_rotary_emb_flash_attn = None
+         if find_spec("flash_attn") is not None:
+-            from flash_attn.ops.triton.rotary import apply_rotary
++            try:
++                from flash_attn.ops.triton.rotary import apply_rotary
+ 
+-            self.apply_rotary_emb_flash_attn = apply_rotary
++                self.apply_rotary_emb_flash_attn = apply_rotary
++            except (ImportError, ModuleNotFoundError):
++                pass
+ 
+     @staticmethod
+diff --git a/vllm/model_executor/models/extract_hidden_states.py b/vllm/model_executor/models/extract_hidden_states.py
+index 608e93d..c967983 100644
+--- a/vllm/model_executor/models/extract_hidden_states.py
++++ b/vllm/model_executor/models/extract_hidden_states.py
+@@ -9,6 +9,7 @@ extract_hidden_states speculative decoding method.
+ """
+ 
+ from collections.abc import Iterable
++from dataclasses import replace
+ from typing import ClassVar
+ 
+ import torch
+@@ -352,6 +353,12 @@ class ExtractHiddenStatesModel(nn.Module):
+ 
+         cache_config = vllm_config.cache_config
+ 
++        # Hidden states dtype should be independent of KV cache dtype.
++        if cache_config is not None and is_quantized_kv_cache(
++            cache_config.cache_dtype
++        ):
++            cache_config = replace(cache_config, cache_dtype="auto")
++
+         # Create a single cache-only attention layer
+         # Note: We set num_heads <- self.num_hidden_states
+         # and head_size <- hidden_size so that we can insert
+diff --git a/vllm/transformers_utils/configs/extract_hidden_states.py b/vllm/transformers_utils/configs/extract_hidden_states.py
+index 5391fbe1ad53..2beec0e3081b 100644
+--- a/vllm/transformers_utils/configs/extract_hidden_states.py
++++ b/vllm/transformers_utils/configs/extract_hidden_states.py
+@@ -23,10 +23,14 @@ def __init__(
+ 
+         if isinstance(model, dict):
+             model_dict = model
++            source_text_config = None
+         elif isinstance(model, PretrainedConfig):
+             model_dict = model.to_dict()
++            text_config = model.get_text_config()
++            source_text_config = text_config if text_config is not model else None
+         else:
+             model_dict = {}
++            source_text_config = None
+ 
+         # Combine: model_dict first, then kwargs override
+         combined = {**model_dict, **kwargs}
+@@ -35,6 +39,12 @@ def __init__(
+ 
+         combined["architectures"] = ["ExtractHiddenStatesModel"]
+ 
++        # to_dict() and kwargs both flatten text_config to a plain dict;
++        # downstream get_hf_text_config() needs it as a PretrainedConfig
++        # for attribute access. Re-insert the original object.
++        if source_text_config is not None:
++            combined["text_config"] = source_text_config
++
+         super().__init__(**combined)
+ 
+     @classmethod

--- a/tools/convert_to_hf.py
+++ b/tools/convert_to_hf.py
@@ -66,6 +66,16 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+_VERSION_FILE = os.path.join(os.path.dirname(__file__), "..", "version.txt")
+
+
+def _get_torchspec_version() -> str:
+    try:
+        with open(_VERSION_FILE) as f:
+            return f.read().strip()
+    except OSError:
+        return "unknown"
+
 
 # ── FSDP loading helpers ─────────────────────────────────────────────────────
 
@@ -249,11 +259,17 @@ def _prepare_export_tensors(hf_model, export_for_vllm: bool) -> dict[str, torch.
 def _save_without_vocab_pruning(
     hf_model, output_dir: str, raw_config: dict, vocab_size: int, export_for_vllm: bool = False
 ) -> None:
+    version = _get_torchspec_version()
     tensors = _prepare_export_tensors(hf_model, export_for_vllm)
-    save_file(tensors, os.path.join(output_dir, "model.safetensors"))
+    save_file(
+        tensors,
+        os.path.join(output_dir, "model.safetensors"),
+        metadata={"torchspec_version": version},
+    )
 
     export_config = _fixup_export_config(raw_config, export_for_vllm=export_for_vllm)
     export_config["draft_vocab_size"] = vocab_size
+    export_config["_torchspec_version"] = version
     actual_dtype = next(iter(tensors.values())).dtype
     export_config["torch_dtype"] = str(actual_dtype).replace("torch.", "")
     with open(os.path.join(output_dir, "config.json"), "w") as f:
@@ -307,10 +323,16 @@ def _save_with_vocab_pruning(
                 draft_vocab_size,
             )
 
-    save_file(tensors, os.path.join(output_dir, "model.safetensors"))
+    version = _get_torchspec_version()
+    save_file(
+        tensors,
+        os.path.join(output_dir, "model.safetensors"),
+        metadata={"torchspec_version": version},
+    )
 
     export_config = _fixup_export_config(raw_config, export_for_vllm=export_for_vllm)
     export_config["draft_vocab_size"] = draft_vocab_size
+    export_config["_torchspec_version"] = version
     actual_dtype = next(iter(tensors.values())).dtype
     export_config["torch_dtype"] = str(actual_dtype).replace("torch.", "")
     with open(os.path.join(output_dir, "config.json"), "w") as f:


### PR DESCRIPTION
## Summary

- Adds a unified patch file for vllm v0.19.0 with three targeted fixes:
  1. **Rotary embedding import**: Gracefully handles missing `flash_attn.ops.triton.rotary` when FA4 is installed, preventing import errors
  2. **Quantized KV cache dtype**: Forces `cache_dtype="auto"` in `ExtractHiddenStatesModel` so hidden-states extraction works correctly with quantized KV caches (e.g. FP8)
  3. **VLM text_config preservation**: Keeps `text_config` as a `PretrainedConfig` object through `to_dict()` round-trips, fixing `get_hf_text_config()` for vision-language models

## Apply

```bash
cd $VLLM_ROOT && git apply /path/to/patches/vllm/v0.19.0/vllm.patch
```

## Test plan

- [ ] Apply patch to clean vllm v0.19.0 checkout and verify it applies cleanly
- [ ] Run inference with FA4 installed to verify rotary embedding fallback
- [ ] Run inference with FP8 KV cache to verify hidden-states extraction
- [ ] Run inference with a VLM model (e.g. Qwen2-VL) to verify text_config handling