### PR TITLE
Add DFlash block diffusion training support

### DIFF
--- a/configs/dflash_qwen3_8b.yaml
+++ b/configs/dflash_qwen3_8b.yaml
@@ -1,0 +1,36 @@
+# DFlash training config for Qwen3-8B target model with SGLang backend.
+#
+# Usage:
+#   python -m torchspec.train_entry --config configs/dflash_qwen3_8b.yaml
+
+model:
+  target_model_path: Qwen/Qwen3-8B
+  draft_model_config: configs/draft_models/qwen3_8b_dflash.json
+  target_model_backend: sglang
+
+dataset:
+  train_data_path: ""  # Set to your dataset path
+  chat_template: qwen
+  defer_tokenization: false  # DFlash requires pre-tokenization
+
+training:
+  draft_algorithm: dflash
+  dflash_num_anchors: 512
+  dflash_loss_decay_gamma: 7.0
+  attention_backend: sdpa
+  micro_batch_size: 2
+  learning_rate: 6e-4
+  max_seq_length: 8192
+  max_grad_norm: 1.0
+  warmup_ratio: 0.04
+  num_epochs: 6
+  training_num_gpus_per_node: 1
+  training_num_nodes: 1
+
+inference:
+  inference_engine_type: sgl
+  sglang:
+    tp_size: 1
+    mem_fraction_static: 0.8
+
+output_dir: ./outputs/dflash_qwen3_8b

--- a/configs/dflash_qwen3_8b_e2e.yaml
+++ b/configs/dflash_qwen3_8b_e2e.yaml
@@ -1,0 +1,57 @@
+# DFlash end-to-end test config for Qwen3-8B
+#
+# GPU allocation: 2 GPUs total
+#   - 1 GPU for inference (SGLang, tp=1)
+#   - 1 GPU for training
+#
+# For testing on machines with multiple GPUs, set CUDA_VISIBLE_DEVICES=0,1
+
+model:
+  target_model_path: Qwen/Qwen3-8B
+  draft_model_config: configs/draft_models/qwen3_8b_dflash.json
+  trust_remote_code: true
+
+dataset:
+  train_data_path: ../examples/data/sample_conversations.jsonl
+  chat_template: qwen
+  prompt_key: conversations
+  defer_tokenization: false
+
+training:
+  draft_algorithm: dflash
+  dflash_num_anchors: 64
+  dflash_loss_decay_gamma: 7.0
+  attention_backend: sdpa
+  micro_batch_size: 1
+  draft_accumulation_steps: 1
+  learning_rate: 6e-4
+  max_concurrent_batches: 1
+  max_grad_norm: 1.0
+  max_seq_length: 4096
+  num_train_steps: 10
+  seed: 42
+  training_num_gpus_per_node: 2
+  training_num_nodes: 1
+  warmup_ratio: 0.04
+
+inference:
+  inference_engine_type: sgl
+  inference_num_gpus: 2
+  inference_num_gpus_per_engine: 2
+  inference_num_gpus_per_node: 4
+  max_sample_pool_size: 32
+  inference_buffer_threshold: 16
+  inference_batch_size: 4
+  sglang:
+    tp_size: 2
+    mem_fraction_static: 0.7
+
+mooncake:
+  master_server_address: null
+  metadata_server: null
+  protocol: tcp
+  global_segment_size: 16GB
+  local_buffer_size: 4GB
+
+output_dir: ./outputs/dflash_qwen3_8b_e2e
+cache_dir: ./cache/dflash_qwen3_8b_e2e

--- a/configs/draft_models/qwen3_8b_dflash.json
+++ b/configs/draft_models/qwen3_8b_dflash.json
@@ -1,0 +1,30 @@
+{
+  "architectures": ["DFlashDraftModel"],
+  "model_type": "qwen3",
+  "hidden_size": 4096,
+  "num_hidden_layers": 5,
+  "num_attention_heads": 32,
+  "num_key_value_heads": 8,
+  "intermediate_size": 12288,
+  "rms_norm_eps": 1e-6,
+  "rope_theta": 1000000,
+  "vocab_size": 151936,
+  "block_size": 16,
+  "num_target_layers": 36,
+  "dflash_config": {
+    "mask_token_id": 151643,
+    "target_layer_ids": null
+  },
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "layer_types": [
+    "full_attention",
+    "full_attention",
+    "full_attention",
+    "full_attention",
+    "full_attention"
+  ],
+  "head_dim": 128,
+  "max_position_embeddings": 40960,
+  "tie_word_embeddings": false
+}

--- a/examples/dflash-qwen3-8b-single-node/run.sh
+++ b/examples/dflash-qwen3-8b-single-node/run.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# DFlash training with SGLang async inference (single-node)
+#
+# GPU allocation (default: 4 GPUs):
+#   - 2 GPUs for inference (SGLang tp=2)
+#   - 2 GPUs for training (FSDP)
+#
+# Usage:
+#   ./examples/dflash-qwen3-8b-single-node/run.sh [CONFIG_FILE] [EXTRA_ARGS...]
+#
+# Examples:
+#   ./examples/dflash-qwen3-8b-single-node/run.sh
+#   ./examples/dflash-qwen3-8b-single-node/run.sh configs/dflash_qwen3_8b_e2e.yaml training.num_train_steps=5
+
+set -euo pipefail
+set -x
+
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0,1,2,3}
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+export TORCHINDUCTOR_CACHE_DIR="$ROOT_DIR/cache/compiled_kernels"
+export TORCHSPEC_LOG_LEVEL=INFO
+
+CONFIG_FILE="${1:-$ROOT_DIR/configs/dflash_qwen3_8b_e2e.yaml}"
+if [[ -f "$CONFIG_FILE" ]]; then
+    shift 1 || true
+elif [[ -f "$ROOT_DIR/$CONFIG_FILE" ]]; then
+    CONFIG_FILE="$ROOT_DIR/$CONFIG_FILE"
+    shift 1 || true
+else
+    CONFIG_FILE="$ROOT_DIR/configs/dflash_qwen3_8b_e2e.yaml"
+fi
+
+IFS=',' read -ra GPU_ARRAY <<< "$CUDA_VISIBLE_DEVICES"
+TOTAL_GPUS=${#GPU_ARRAY[@]}
+
+TRAIN_GPUS=2
+INFERENCE_GPUS=2
+
+echo "=============================================="
+echo "DFlash Training with async inference"
+echo "=============================================="
+echo "Config: $CONFIG_FILE"
+echo "Total GPUs: $TOTAL_GPUS (CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES)"
+echo "  - Training GPUs: $TRAIN_GPUS"
+echo "  - Inference GPUs: $INFERENCE_GPUS"
+echo "Extra args: $*"
+echo "=============================================="
+
+python3 -m torchspec.train_entry \
+    --config "$CONFIG_FILE" \
+    training.training_num_gpus_per_node="$TRAIN_GPUS" \
+    inference.inference_num_gpus="$INFERENCE_GPUS" \
+    inference.inference_num_gpus_per_engine=2 \
+    inference.inference_num_gpus_per_node="$TOTAL_GPUS" \
+    inference.sglang.tp_size=2 \
+    "$@"
+
+echo "=============================================="
+echo "DFlash training completed!"
+echo "=============================================="

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2026 LightSeek Foundation
+# Tests for DFlash training implementation.
+# Verifies precision alignment with SpecForge and dataflow integration.
+
+import unittest
+
+import torch
+
+
+def _reference_dflash_mask(anchor_positions, block_keep_mask, S, block_size, device):
+    """Element-level reference mask using Python loops.
+
+    Copied from SpecForge/tests/test_utils/test_dflash_mask.py for precision alignment.
+    """
+    B, N = anchor_positions.shape
+    Q_LEN = N * block_size
+    KV_LEN = S + N * block_size
+
+    mask = torch.zeros(B, 1, Q_LEN, KV_LEN, dtype=torch.bool, device=device)
+    for b in range(B):
+        for q_idx in range(Q_LEN):
+            q_block_id = q_idx // block_size
+            anchor_pos = anchor_positions[b, q_block_id].item()
+            is_valid = block_keep_mask[b, q_block_id].item()
+            if not is_valid:
+                continue
+            for kv_idx in range(KV_LEN):
+                is_context = kv_idx < S
+                ctx_visible = is_context and (kv_idx < anchor_pos)
+                is_draft = kv_idx >= S
+                kv_block_id = (kv_idx - S) // block_size
+                draft_visible = is_draft and (q_block_id == kv_block_id)
+                if ctx_visible or draft_visible:
+                    mask[b, 0, q_idx, kv_idx] = True
+    return mask
+
+
+class TestBuildTargetLayerIds(unittest.TestCase):
+    def test_single_layer(self):
+        from torchspec.models.draft.dflash import build_target_layer_ids
+
+        self.assertEqual(build_target_layer_ids(36, 1), [18])
+        self.assertEqual(build_target_layer_ids(28, 1), [14])
+
+    def test_multi_layer(self):
+        from torchspec.models.draft.dflash import build_target_layer_ids
+
+        ids = build_target_layer_ids(36, 5)
+        self.assertEqual(len(ids), 5)
+        self.assertEqual(ids[0], 1)
+        self.assertEqual(ids[-1], 33)
+        # All IDs should be unique and sorted
+        self.assertEqual(ids, sorted(set(ids)))
+
+    def test_two_layers(self):
+        from torchspec.models.draft.dflash import build_target_layer_ids
+
+        ids = build_target_layer_ids(36, 2)
+        self.assertEqual(len(ids), 2)
+        self.assertEqual(ids[0], 1)
+        self.assertEqual(ids[1], 33)
+
+
+class TestDFlashSdpaMask(unittest.TestCase):
+    def setUp(self):
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    def _compare_masks(self, anchor_positions, block_keep_mask, S, block_size):
+        from torchspec.models.dflash import create_dflash_sdpa_mask
+
+        anchor_positions = anchor_positions.to(self.device)
+        block_keep_mask = block_keep_mask.to(self.device)
+
+        sdpa_mask = create_dflash_sdpa_mask(
+            anchor_positions=anchor_positions,
+            block_keep_mask=block_keep_mask,
+            S=S,
+            block_size=block_size,
+            device=self.device,
+        )
+        ref_mask = _reference_dflash_mask(
+            anchor_positions=anchor_positions,
+            block_keep_mask=block_keep_mask,
+            S=S,
+            block_size=block_size,
+            device=self.device,
+        )
+        self.assertEqual(sdpa_mask.shape, ref_mask.shape)
+        self.assertTrue(
+            torch.equal(sdpa_mask, ref_mask),
+            f"Mask mismatch with S={S}, block_size={block_size}",
+        )
+
+    def test_single_batch_single_block(self):
+        self._compare_masks(torch.tensor([[64]]), torch.tensor([[True]]), S=128, block_size=4)
+
+    def test_single_batch_multi_block(self):
+        self._compare_masks(
+            torch.tensor([[32, 64, 96]]),
+            torch.tensor([[True, True, True]]),
+            S=128,
+            block_size=4,
+        )
+
+    def test_multi_batch(self):
+        self._compare_masks(
+            torch.tensor([[16, 48, 80], [32, 64, 100]]),
+            torch.tensor([[True, True, True], [True, True, True]]),
+            S=128,
+            block_size=4,
+        )
+
+    def test_invalid_blocks(self):
+        self._compare_masks(
+            torch.tensor([[20, 50, 80, 110]]),
+            torch.tensor([[True, False, True, False]]),
+            S=128,
+            block_size=4,
+        )
+
+    def test_all_blocks_invalid(self):
+        self._compare_masks(
+            torch.tensor([[30, 60]]),
+            torch.tensor([[False, False]]),
+            S=128,
+            block_size=4,
+        )
+
+    def test_anchor_at_zero(self):
+        self._compare_masks(
+            torch.tensor([[0, 64]]),
+            torch.tensor([[True, True]]),
+            S=128,
+            block_size=4,
+        )
+
+    def test_various_block_sizes(self):
+        for block_size in [1, 2, 4, 8, 16]:
+            with self.subTest(block_size=block_size):
+                self._compare_masks(
+                    torch.tensor([[32, 80]]),
+                    torch.tensor([[True, True]]),
+                    S=128,
+                    block_size=block_size,
+                )
+
+    def test_random_stress(self):
+        rng = torch.Generator().manual_seed(123)
+        for trial in range(5):
+            with self.subTest(trial=trial):
+                B = torch.randint(1, 4, (1,), generator=rng).item()
+                N = torch.randint(1, 8, (1,), generator=rng).item()
+                S = 64 * torch.randint(1, 5, (1,), generator=rng).item()
+                block_size = [1, 2, 4, 8][torch.randint(0, 4, (1,), generator=rng).item()]
+                anchor_positions = torch.stack(
+                    [torch.randperm(S, generator=rng)[:N].sort().values for _ in range(B)]
+                )
+                block_keep_mask = torch.rand(B, N, generator=rng) > 0.3
+                self._compare_masks(anchor_positions, block_keep_mask, S=S, block_size=block_size)
+
+
+class TestDataflowIntegration(unittest.TestCase):
+    """Test that DFlash-style samples flow through the collator correctly."""
+
+    def test_collator_accepts_dflash_samples(self):
+        from torchspec.data.utils import DataCollatorWithPadding
+
+        collator = DataCollatorWithPadding()
+        hidden_size = 128
+        num_layers = 3
+
+        # DFlash samples: hidden_states + input_ids, no target/last_hidden_states
+        samples = []
+        for seq_len in [32, 48]:
+            samples.append(
+                {
+                    "input_ids": torch.randint(0, 1000, (1, seq_len)),
+                    "hidden_states": torch.randn(1, seq_len, num_layers * hidden_size),
+                    "loss_mask": torch.ones(1, seq_len),
+                }
+            )
+
+        batch = collator(samples)
+
+        self.assertIn("input_ids", batch)
+        self.assertIn("hidden_states", batch)
+        self.assertIn("loss_mask", batch)
+        self.assertIsNotNone(batch["hidden_states"])
+        self.assertIsNone(batch["target"])
+        self.assertIsNone(batch["last_hidden_states"])
+        self.assertEqual(batch["input_ids"].shape[0], 2)
+        self.assertEqual(batch["hidden_states"].shape[0], 2)
+        # Padded to max length
+        self.assertEqual(batch["input_ids"].shape[1], 48)
+
+
+class TestDFlashSampleFilter(unittest.TestCase):
+    """Test that DFlash minimum sample filter works with packed_loss_mask."""
+
+    def test_filter_by_min_loss_tokens(self):
+        from torchspec.data.utils import (
+            pack_loss_mask,
+            serialize_packed_loss_mask,
+            unpack_loss_mask,
+        )
+
+        block_size = 16
+        min_loss_tokens = 2 * block_size
+
+        # Sample with enough loss tokens (40 > 32)
+        mask_good = torch.zeros(100, dtype=torch.long)
+        mask_good[10:50] = 1
+        packed_good = serialize_packed_loss_mask(pack_loss_mask(mask_good))
+        self.assertTrue(unpack_loss_mask(packed_good).sum() >= min_loss_tokens)
+
+        # Sample with too few loss tokens (10 < 32)
+        mask_bad = torch.zeros(100, dtype=torch.long)
+        mask_bad[10:20] = 1
+        packed_bad = serialize_packed_loss_mask(pack_loss_mask(mask_bad))
+        self.assertTrue(unpack_loss_mask(packed_bad).sum() < min_loss_tokens)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestDFlashDraftModelForward(unittest.TestCase):
+    """Test DFlashDraftModel forward pass on GPU."""
+
+    def test_forward_produces_output(self):
+        from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+
+        from torchspec.models.draft.dflash import DFlashDraftModel
+
+        config = Qwen3Config(
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            intermediate_size=128,
+            vocab_size=256,
+            rms_norm_eps=1e-6,
+            rope_theta=10000,
+            attention_bias=False,
+            attention_dropout=0.0,
+            max_position_embeddings=512,
+            head_dim=16,
+            layer_types=["full_attention", "full_attention"],
+        )
+        config.block_size = 8
+        config.num_target_layers = 12
+        config.dflash_config = {"mask_token_id": 0, "target_layer_ids": None}
+
+        torch.manual_seed(42)
+        model = DFlashDraftModel(config).cuda().bfloat16()
+
+        bsz, seq_len, block_size = 2, 32, 8
+        n_blocks = 4
+        n_ctx_features = len(model.target_layer_ids)
+
+        noise_embed = torch.randn(
+            bsz, n_blocks * block_size, 64, device="cuda", dtype=torch.bfloat16
+        )
+        target_hidden = torch.randn(
+            bsz, seq_len, n_ctx_features * 64, device="cuda", dtype=torch.bfloat16
+        )
+        pos_ids = (
+            torch.arange(seq_len + n_blocks * block_size, device="cuda")
+            .unsqueeze(0)
+            .expand(bsz, -1)
+        )
+
+        output = model(
+            position_ids=pos_ids,
+            noise_embedding=noise_embed,
+            target_hidden=target_hidden,
+        )
+
+        self.assertEqual(output.shape, (bsz, n_blocks * block_size, 64))
+        self.assertFalse(torch.isnan(output).any())
+        self.assertFalse(torch.isinf(output).any())
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestDFlashModelLoss(unittest.TestCase):
+    """Test DFlashModel training wrapper forward + loss on GPU."""
+
+    def test_forward_loss_and_accuracy(self):
+        from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+
+        from torchspec.models.dflash import DFlashModel
+        from torchspec.models.draft.dflash import DFlashDraftModel
+
+        config = Qwen3Config(
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            intermediate_size=128,
+            vocab_size=256,
+            rms_norm_eps=1e-6,
+            rope_theta=10000,
+            attention_bias=False,
+            attention_dropout=0.0,
+            max_position_embeddings=512,
+            head_dim=16,
+            layer_types=["full_attention", "full_attention"],
+        )
+        config.block_size = 4
+        config.num_target_layers = 12
+        config.dflash_config = {"mask_token_id": 0, "target_layer_ids": None}
+
+        torch.manual_seed(42)
+        draft_model = DFlashDraftModel(config).cuda().bfloat16()
+        n_ctx_features = len(draft_model.target_layer_ids)
+
+        lm_head = torch.nn.Linear(64, 256, bias=False).cuda().bfloat16()
+        embed_tokens = torch.nn.Embedding(256, 64).cuda().bfloat16()
+
+        dflash_model = DFlashModel(
+            draft_model=draft_model,
+            target_lm_head=lm_head,
+            target_embed_tokens=embed_tokens,
+            mask_token_id=0,
+            block_size=4,
+            attention_backend="sdpa",
+            num_anchors=8,
+            loss_decay_gamma=5.0,
+        )
+
+        bsz, seq_len = 2, 64
+        input_ids = torch.randint(1, 256, (bsz, seq_len), device="cuda")
+        hidden_states = torch.randn(
+            bsz, seq_len, n_ctx_features * 64, device="cuda", dtype=torch.bfloat16
+        )
+        loss_mask = torch.ones(bsz, seq_len, device="cuda")
+        loss_mask[:, :4] = 0  # mask out first few tokens
+
+        loss, accuracy = dflash_model(input_ids, hidden_states, loss_mask)
+
+        self.assertFalse(torch.isnan(loss))
+        self.assertGreater(loss.item(), 0)
+        self.assertGreaterEqual(accuracy.item(), 0)
+        self.assertLessEqual(accuracy.item(), 1)
+
+        # Verify backward works
+        loss.backward()
+        has_grad = any(
+            p.grad is not None and p.grad.abs().sum() > 0
+            for p in draft_model.parameters()
+            if p.requires_grad
+        )
+        self.assertTrue(has_grad, "Draft model should have gradients after backward")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/convert_dflash_to_hf.py
+++ b/tools/convert_dflash_to_hf.py
@@ -1,0 +1,207 @@
+"""
+Convert DFlash FSDP checkpoint to HuggingFace safetensors format.
+
+Usage:
+    python tools/convert_dflash_to_hf.py --input-dir <checkpoint_dir>
+
+    python tools/convert_dflash_to_hf.py --input-dir <checkpoint_dir> \
+        --config configs/draft_models/qwen3_8b_dflash.json
+
+Options:
+    --input-dir     Path to FSDP checkpoint directory (required)
+    --output-dir    Output directory (default: {input_dir}_hf)
+    --config        Path to draft model config.json (default: {input_dir}/config.json)
+    --dtype         Output dtype (float16, bfloat16, float32)
+    -f, --force     Overwrite output directory if exists
+"""
+
+import argparse
+import json
+import logging
+import os
+import pickle
+from typing import Optional
+
+import torch
+import torch.distributed.checkpoint as dist_cp
+from safetensors.torch import save_file
+from typing_extensions import override
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] %(levelname)s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+_VERSION_FILE = os.path.join(os.path.dirname(__file__), "..", "version.txt")
+
+
+def _get_torchspec_version() -> str:
+    try:
+        with open(_VERSION_FILE) as f:
+            return f.read().strip()
+    except OSError:
+        return "unknown"
+
+
+class _UnpicklerWrapper(pickle.Unpickler):
+    @override
+    def find_class(self, mod_name, name):
+        class DummyClass:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        if mod_name.startswith("megatron") or mod_name.startswith("glm"):
+            return DummyClass
+        return super().find_class(mod_name, name)
+
+
+class _WrappedStorageReader(dist_cp.FileSystemReader):
+    @override
+    def read_metadata(self):
+        path = self.fs.concat_path(self.path, ".metadata")
+        with self.fs.create_stream(path, "rb") as metadata_file:
+            metadata = _UnpicklerWrapper(metadata_file).load()
+        if getattr(metadata, "storage_meta", None) is None:
+            metadata.storage_meta = dist_cp.StorageMeta()
+        metadata.storage_meta.load_id = self.load_id
+        if metadata.planner_data is None:
+            metadata.planner_data = {}
+        return metadata
+
+
+class _EmptyStateDictLoadPlanner(dist_cp.default_planner.DefaultLoadPlanner):
+    @override
+    def set_up_planner(self, state_dict, metadata=None, is_coordinator=False):
+        for k, v in metadata.state_dict_metadata.items():
+            if "optimizer" in k:
+                continue
+            if isinstance(v, dist_cp.metadata.TensorStorageMetadata):
+                v = torch.empty(v.size, dtype=v.properties.dtype)
+            state_dict[k] = v
+        super().set_up_planner(state_dict, metadata, is_coordinator)
+
+
+def _detect_model_dir(input_dir: str) -> str:
+    model_dir = os.path.join(input_dir, "model")
+    return model_dir if os.path.isdir(model_dir) else input_dir
+
+
+def _load_fsdp_state_dict(input_dir: str) -> dict[str, torch.Tensor]:
+    state_dict: dict[str, torch.Tensor] = {}
+    dist_cp.state_dict_loader._load_state_dict(
+        state_dict,
+        storage_reader=_WrappedStorageReader(input_dir),
+        planner=_EmptyStateDictLoadPlanner(),
+        no_dist=True,
+    )
+    return state_dict
+
+
+def _extract_draft_model_weights(
+    state_dict: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    """Extract DFlash draft model weights from FSDP checkpoint."""
+    model_state = {}
+    skipped_keys = []
+
+    for k, v in state_dict.items():
+        if not isinstance(v, torch.Tensor):
+            continue
+        if "draft_model." not in k:
+            skipped_keys.append(k)
+            continue
+        new_key = k.split("draft_model.")[-1]
+        model_state[new_key] = v
+
+    logger.info(
+        "Extracted %d model weight keys (skipped %d non-draft keys)",
+        len(model_state),
+        len(skipped_keys),
+    )
+    return model_state
+
+
+def convert(
+    input_dir: str,
+    output_dir: str,
+    config_path: str,
+    dtype: Optional[str] = None,
+) -> None:
+    model_dir = _detect_model_dir(input_dir)
+    logger.info("Loading FSDP checkpoint from %s", model_dir)
+
+    state_dict = _load_fsdp_state_dict(model_dir)
+    model_weights = _extract_draft_model_weights(state_dict)
+    del state_dict
+
+    # Load config
+    with open(config_path) as f:
+        raw_config = json.load(f)
+
+    # Instantiate model to validate weight shapes
+    from torchspec.models.draft.auto import AutoDraftModelConfig
+    from torchspec.models.draft.dflash import DFlashDraftModel
+
+    draft_config = AutoDraftModelConfig.from_dict(raw_config)
+    model = DFlashDraftModel(draft_config)
+
+    # Load weights into model
+    missing, unexpected = model.load_state_dict(model_weights, strict=False)
+    if missing:
+        logger.warning("Missing keys: %s", missing)
+    if unexpected:
+        logger.warning("Unexpected keys: %s", unexpected)
+
+    # Cast dtype if requested
+    if dtype:
+        dtype_map = {"float16": torch.float16, "bfloat16": torch.bfloat16, "float32": torch.float32}
+        model = model.to(dtype=dtype_map[dtype])
+
+    # Save
+    os.makedirs(output_dir, exist_ok=True)
+    tensors = model.state_dict()
+
+    version = _get_torchspec_version()
+    save_file(
+        tensors,
+        os.path.join(output_dir, "model.safetensors"),
+        metadata={"torchspec_version": version},
+    )
+
+    export_config = json.loads(json.dumps(raw_config))
+    export_config["_torchspec_version"] = version
+    actual_dtype = next(iter(tensors.values())).dtype
+    export_config["torch_dtype"] = str(actual_dtype).replace("torch.", "")
+    with open(os.path.join(output_dir, "config.json"), "w") as f:
+        json.dump(export_config, f, indent=2)
+
+    logger.info("DFlash model saved to %s (%d tensors)", output_dir, len(tensors))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert DFlash FSDP checkpoint to HF format")
+    parser.add_argument("--input-dir", required=True, help="FSDP checkpoint directory")
+    parser.add_argument("--output-dir", default=None, help="Output directory (default: {input}_hf)")
+    parser.add_argument("--config", default=None, help="Draft model config.json path")
+    parser.add_argument("--dtype", choices=["float16", "bfloat16", "float32"], default=None)
+    parser.add_argument("-f", "--force", action="store_true", help="Overwrite output if exists")
+    args = parser.parse_args()
+
+    output_dir = args.output_dir or f"{args.input_dir}_hf"
+    if os.path.exists(output_dir) and not args.force:
+        logger.error("%s already exists. Use -f to overwrite.", output_dir)
+        return
+
+    config_path = args.config
+    if config_path is None:
+        config_path = os.path.join(args.input_dir, "config.json")
+        if not os.path.isfile(config_path):
+            raise FileNotFoundError(f"config.json not found in {args.input_dir}. Provide --config.")
+
+    convert(args.input_dir, output_dir, config_path, args.dtype)
+
+
+if __name__ == "__main__":
+    main()

--- a/torchspec/__init__.py
+++ b/torchspec/__init__.py
@@ -20,11 +20,19 @@
 
 """TorchSpec - Torch native spec decode training framework."""
 
-from torchspec.models import Eagle3Model
-from torchspec.models.draft import AutoDraftModelConfig, AutoEagle3DraftModel
+from torchspec.models import DFlashModel, Eagle3Model
+from torchspec.models.draft import (
+    AutoDFlashDraftModel,
+    AutoDraftModelConfig,
+    AutoEagle3DraftModel,
+    DFlashDraftModel,
+)
 
 __all__ = [
-    "Eagle3Model",
+    "AutoDFlashDraftModel",
     "AutoDraftModelConfig",
     "AutoEagle3DraftModel",
+    "DFlashDraftModel",
+    "DFlashModel",
+    "Eagle3Model",
 ]

--- a/torchspec/config/train_config.py
+++ b/torchspec/config/train_config.py
@@ -96,6 +96,9 @@ class TrainingConfig:
     attention_backend: str = "sdpa"
     colocate: bool = False
     continual_training: bool = False
+    dflash_loss_decay_gamma: Optional[float] = None
+    dflash_num_anchors: int = 512
+    draft_algorithm: str = "eagle3"
     distributed_backend: str = "nccl"
     distributed_timeout_minutes: int = 10
     draft_accumulation_steps: int = 1

--- a/torchspec/data/dataset.py
+++ b/torchspec/data/dataset.py
@@ -156,11 +156,14 @@ def load_conversation_dataset(args):
         file_stat = f"-{st.st_size}-{st.st_mtime}"
     last_turn_loss_only_flag = getattr(args, "last_turn_loss_only", False)
     train_with_decode = getattr(args, "train_with_decode", False)
+    dflash_min_loss_tokens = getattr(args, "dflash_min_loss_tokens", None)
     cache_params = (
         f"{dataset_name}-{args.train_data_path}{file_stat}-{args.target_model_path}"
         f"-{max_length}-{chat_template_name}-ltlo={last_turn_loss_only_flag}"
         f"-defer={defer_tokenization}-decode={train_with_decode}"
     )
+    if dflash_min_loss_tokens is not None:
+        cache_params += f"-dflash_min={dflash_min_loss_tokens}"
     cache_key = hashlib.md5(cache_params.encode()).hexdigest()
     cache_dir = os.path.join(getattr(args, "cache_dir", "./cache"), "tokenized_dataset")
     cache_path = os.path.join(cache_dir, f"{cache_key}.pt")
@@ -168,6 +171,18 @@ def load_conversation_dataset(args):
     if os.path.exists(cache_path):
         logger.info(f"Loading dataset from cache: {cache_path}")
         prompts = torch.load(cache_path, weights_only=False)
+        # Defensive: re-apply DFlash min sample filter on cache hit
+        if dflash_min_loss_tokens is not None:
+            from torchspec.data.utils import unpack_loss_mask
+
+            before = len(prompts)
+            prompts = [
+                p
+                for p in prompts
+                if unpack_loss_mask(p["packed_loss_mask"]).sum() >= dflash_min_loss_tokens
+            ]
+            if len(prompts) < before:
+                logger.info(f"DFlash sample filter on cache: {before} -> {len(prompts)} samples")
         logger.info(f"Loaded {len(prompts)} cached samples")
         return prompts
 
@@ -254,6 +269,15 @@ def load_conversation_dataset(args):
                 input_ids = torch.tensor(input_ids)
             entry["input_ids"] = input_ids
             entry["packed_loss_mask"] = result["packed_loss_mask"]
+
+            # DFlash: filter samples with too few valid loss positions
+            if dflash_min_loss_tokens is not None:
+                from torchspec.data.utils import unpack_loss_mask
+
+                mask = unpack_loss_mask(result["packed_loss_mask"])
+                if mask.sum() < dflash_min_loss_tokens:
+                    skipped += 1
+                    continue
 
         prompts.append(entry)
 

--- a/torchspec/data/utils.py
+++ b/torchspec/data/utils.py
@@ -102,10 +102,6 @@ class DataCollatorWithPadding:
             )
             has_target = all(item.get("target") is not None for item in features)
             has_last_hs = all(item.get("last_hidden_states") is not None for item in features)
-            if not has_target and not has_last_hs:
-                raise ValueError(
-                    "Either 'target' or 'last_hidden_states' is required when 'hidden_states' is provided"
-                )
             if has_target:
                 batch["target"] = torch.cat(
                     [self.paddingtensor(item["target"], max_length) for item in features]

--- a/torchspec/inference/engine/sgl_engine.py
+++ b/torchspec/inference/engine/sgl_engine.py
@@ -166,8 +166,30 @@ class SglEngine(SglDecodeEngineMixin, InferenceEngine, RayActor):
         # Get configuration
         mem_fraction = getattr(self.args, "sglang_mem_fraction_static", 0.8)
         pp_size = getattr(self.args, "sglang_pp_size", 1)
+        self._draft_algorithm = getattr(self.args, "draft_algorithm", "eagle3")
         if self.args.aux_hidden_states_layers is not None:
             self.aux_hidden_state_layer_ids = self.args.aux_hidden_states_layers
+        elif self._draft_algorithm == "dflash":
+            # DFlash: compute layer IDs from draft config (single source of truth)
+            from torchspec.models.draft.dflash import build_target_layer_ids
+
+            draft_cfg = getattr(self.args, "draft_model_config_obj", None)
+            num_target_layers = getattr(draft_cfg, "num_target_layers", None)
+            num_draft_layers = getattr(draft_cfg, "num_hidden_layers", None)
+            if num_target_layers is None or num_draft_layers is None:
+                raise ValueError(
+                    "DFlash requires num_target_layers and num_hidden_layers in the draft config"
+                )
+            dflash_config = getattr(draft_cfg, "dflash_config", {}) or {}
+            explicit_ids = dflash_config.get("target_layer_ids", None)
+            if explicit_ids is not None:
+                self.aux_hidden_state_layer_ids = explicit_ids
+            else:
+                self.aux_hidden_state_layer_ids = build_target_layer_ids(
+                    num_target_layers, num_draft_layers
+                )
+            if self.rank == 0:
+                logger.info(f"DFlash aux hidden state layer ids: {self.aux_hidden_state_layer_ids}")
         else:
             self.aux_hidden_state_layer_ids = get_default_eagle3_aux_layer_ids(
                 self.args.target_model_path
@@ -243,6 +265,12 @@ class SglEngine(SglDecodeEngineMixin, InferenceEngine, RayActor):
                 "chunked_prefill_size": -1,
                 "allow_auto_truncate": True,
                 **({"context_length": max_seq_length} if max_seq_length else {}),
+                # DFlash: suppress last_hidden_states storage in Mooncake
+                **(
+                    {"spec_training_store_last_hidden_states": False}
+                    if self._draft_algorithm == "dflash"
+                    else {}
+                ),
             }
         )
 
@@ -532,16 +560,21 @@ class SglEngine(SglDecodeEngineMixin, InferenceEngine, RayActor):
         # IMPORTANT: Sglang stores tensors WITHOUT batch dimension in mooncake
         # We must request the SAME shapes that sglang stored, otherwise we get size mismatch
         # The collator will add batch dimension when needed
-        return {
+        shapes = {
             "hidden_states": (seq_len, concat_hidden_size),  # 2D without batch dim
             "input_ids": (seq_len,),  # 1D without batch dim
-            "last_hidden_states": (seq_len, hidden_size),  # 2D without batch dim
         }
+        # DFlash does not use last_hidden_states
+        if self._draft_algorithm != "dflash":
+            shapes["last_hidden_states"] = (seq_len, hidden_size)  # 2D without batch dim
+        return shapes
 
     def _get_tensor_dtypes(self) -> dict:
         """Get tensor dtypes for mooncake metadata."""
-        return {
+        dtypes = {
             "hidden_states": HIDDEN_STATES_STORAGE_DTYPE,
             "input_ids": torch.long,
-            "last_hidden_states": HIDDEN_STATES_STORAGE_DTYPE,
         }
+        if self._draft_algorithm != "dflash":
+            dtypes["last_hidden_states"] = HIDDEN_STATES_STORAGE_DTYPE
+        return dtypes

--- a/torchspec/models/__init__.py
+++ b/torchspec/models/__init__.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from torchspec.models.dflash import DFlashModel
 from torchspec.models.eagle3 import (
     Eagle3Model,
     compute_lazy_target_padded,
@@ -27,6 +28,7 @@ from torchspec.models.ops.loss import compiled_forward_kl_loss
 from torchspec.models.ops.loss_mask import compute_assistant_loss_mask
 
 __all__ = [
+    "DFlashModel",
     "Eagle3Model",
     "compute_lazy_target_padded",
     "compute_target_p_padded",

--- a/torchspec/models/dflash.py
+++ b/torchspec/models/dflash.py
@@ -1,0 +1,304 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""DFlash training wrapper with block-wise parallel CE loss."""
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from torchspec.models.draft.dflash import DFlashDraftModel
+
+try:
+    from torch.nn.attention.flex_attention import BlockMask, create_block_mask
+
+    FLEX_ATTENTION_AVAILABLE = True
+except ImportError:
+    FLEX_ATTENTION_AVAILABLE = False
+    BlockMask = None
+    create_block_mask = None
+
+
+def create_dflash_sdpa_mask(anchor_positions, block_keep_mask, S, block_size, device):
+    """Create 4D boolean SDPA attention mask for DFlash training.
+
+    KV: [Context (S tokens) | Block_0 | Block_1 | ... | Block_{n-1}]
+    Q:  [Block_0 | Block_1 | ... | Block_{n-1}]
+
+    Rules:
+      1. Each block sees context strictly before its anchor (kv_idx < anchor_pos).
+      2. Intra-block attention is bidirectional.
+      3. Different blocks are invisible to each other.
+      4. Invalid blocks (block_keep_mask=False) see nothing.
+    """
+    B, N = anchor_positions.shape
+    Q_LEN = N * block_size
+    KV_LEN = S + N * block_size
+
+    q_indices = torch.arange(Q_LEN, device=device).view(1, 1, -1, 1)
+    kv_indices = torch.arange(KV_LEN, device=device).view(1, 1, 1, -1)
+
+    q_block_ids = q_indices // block_size
+
+    anchor_expanded = anchor_positions.view(B, 1, N, 1).repeat_interleave(block_size, dim=2)
+
+    mask_context = (kv_indices < S) & (kv_indices < anchor_expanded)
+
+    is_draft = kv_indices >= S
+    kv_block_ids = (kv_indices - S) // block_size
+    mask_draft = is_draft & (q_block_ids == kv_block_ids)
+
+    valid_block = block_keep_mask.view(B, 1, N, 1).repeat_interleave(block_size, dim=2)
+
+    final_mask = (mask_context | mask_draft) & valid_block
+    return final_mask
+
+
+def create_dflash_block_mask(
+    anchor_positions: torch.Tensor,
+    block_keep_mask: torch.Tensor,
+    S: int,
+    block_size: int,
+    device: torch.device,
+):
+    """Construct Flex Attention BlockMask for DFlash training.
+
+    Same semantics as create_dflash_sdpa_mask but uses hardware-optimized
+    block-level masking via torch.nn.attention.flex_attention.
+    """
+
+    def dflash_mask_mod(b, h, q_idx, kv_idx):
+        q_block_id = q_idx // block_size
+        safe_q_block_id = q_block_id.clamp(max=N - 1)
+        anchor_pos = anchor_positions[b, safe_q_block_id]
+
+        is_context = kv_idx < S
+        mask_context = is_context & (kv_idx < anchor_pos)
+
+        is_draft = kv_idx >= S
+        kv_block_id = (kv_idx - S) // block_size
+        mask_draft = is_draft & (q_block_id == kv_block_id)
+
+        is_valid_block = block_keep_mask[b, safe_q_block_id]
+        in_bounds = q_block_id < N
+        return (mask_context | mask_draft) & is_valid_block & in_bounds
+
+    B, N = anchor_positions.shape
+    Q_LEN = N * block_size
+    KV_LEN = S + N * block_size
+
+    return create_block_mask(
+        dflash_mask_mod, B=B, H=None, Q_LEN=Q_LEN, KV_LEN=KV_LEN, device=device
+    )
+
+
+class DFlashModel(nn.Module):
+    """DFlash training wrapper with block-wise CE loss.
+
+    Analogous to Eagle3Model but for DFlash's parallel block generation.
+    """
+
+    def __init__(
+        self,
+        draft_model: DFlashDraftModel,
+        target_lm_head: nn.Module,
+        target_embed_tokens: nn.Module,
+        mask_token_id: int,
+        block_size: int = 16,
+        attention_backend: str = "flex_attention",
+        num_anchors: int = 512,
+        loss_decay_gamma: Optional[float] = None,
+    ):
+        super().__init__()
+        self.draft_model = draft_model
+        self.lm_head = target_lm_head
+        self.embed_tokens = target_embed_tokens
+        self.block_size = block_size
+        self.mask_token_id = mask_token_id
+        self.attention_backend = attention_backend
+        self.num_anchors = num_anchors
+        self.loss_decay_gamma = loss_decay_gamma
+
+    def _sample_anchor_positions(
+        self, seq_len: int, loss_mask: torch.Tensor, device: torch.device
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Randomly sample anchor positions per sample; returns (anchors, keep_mask)."""
+        bs = self.block_size
+        bsz = loss_mask.shape[0]
+        max_anchor = max(seq_len - bs, 0)
+
+        valid = loss_mask[:, : max_anchor + 1] > 0.5
+        valid_counts = valid.sum(dim=1)
+        max_n = min(self.num_anchors, int(valid_counts.max().item()) - 1)
+
+        if max_n <= 0:
+            raise ValueError("should preprocess the data.")
+
+        indices = torch.arange(max_anchor + 1, device=device).unsqueeze(0).expand(bsz, -1)
+        masked_indices = torch.where(valid, indices, torch.tensor(seq_len + 1, device=device))
+
+        random_vals = torch.rand(bsz, max_anchor + 1, device=device)
+        random_vals = torch.where(valid, random_vals, torch.tensor(2.0, device=device))
+
+        _, sorted_idx = random_vals.sort(dim=1)
+        gathered = torch.gather(masked_indices, 1, sorted_idx)
+        anchors = gathered[:, :max_n].sort(dim=1).values
+
+        keep_mask = torch.arange(max_n, device=device).unsqueeze(0) < valid_counts.unsqueeze(
+            1
+        ).clamp(max=max_n)
+        anchors = torch.where(keep_mask, anchors, torch.tensor(0, dtype=torch.long, device=device))
+
+        return anchors, keep_mask
+
+    def _create_position_ids(self, anchor_positions: torch.Tensor) -> torch.Tensor:
+        """Create absolute position IDs for parallel draft blocks."""
+        bsz, n_blocks = anchor_positions.shape
+        device = anchor_positions.device
+        offsets = torch.arange(self.block_size, device=device).view(1, 1, -1)
+        pos_ids = anchor_positions.unsqueeze(-1) + offsets
+        return pos_ids.view(bsz, -1)
+
+    def _create_noise_embed(self, input_ids, anchor_positions, block_keep_mask):
+        bsz, seq_len = input_ids.shape
+        n = anchor_positions.shape[1]
+        bs = self.block_size
+        device = input_ids.device
+
+        noise_ids = torch.full((bsz, n * bs), self.mask_token_id, dtype=torch.long, device=device)
+
+        block_starts = torch.arange(n, device=device) * bs
+        block_starts = block_starts.unsqueeze(0).expand(bsz, -1)
+
+        valid_anchor_positions = anchor_positions.clamp(0, seq_len - 1)
+        anchor_tokens = torch.gather(input_ids, 1, valid_anchor_positions)
+
+        flat_batch_idx = torch.arange(bsz, device=device).unsqueeze(1).expand(bsz, n)
+        noise_ids[flat_batch_idx, block_starts] = torch.where(
+            block_keep_mask,
+            anchor_tokens,
+            torch.tensor(self.mask_token_id, dtype=torch.long, device=device),
+        )
+
+        return self.embed_tokens(noise_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        loss_mask: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Parallel block-wise training forward pass.
+
+        Returns:
+            (loss, accuracy) tuple.
+        """
+        bsz, seq_len = input_ids.shape
+        device = input_ids.device
+
+        anchor_positions, block_keep_mask = self._sample_anchor_positions(
+            seq_len, loss_mask, device
+        )
+
+        noise_embedding = self._create_noise_embed(input_ids, anchor_positions, block_keep_mask)
+
+        context_position_ids = torch.arange(seq_len, device=device).unsqueeze(0).expand(bsz, -1)
+        draft_position_ids = self._create_position_ids(anchor_positions)
+        full_position_ids = torch.cat([context_position_ids, draft_position_ids], dim=1)
+
+        if self.attention_backend == "flex_attention":
+            dflash_attn_mask = create_dflash_block_mask(
+                anchor_positions=anchor_positions,
+                block_keep_mask=block_keep_mask,
+                S=seq_len,
+                block_size=self.block_size,
+                device=device,
+            )
+        else:
+            dflash_attn_mask = create_dflash_sdpa_mask(
+                anchor_positions=anchor_positions,
+                block_keep_mask=block_keep_mask,
+                S=seq_len,
+                block_size=self.block_size,
+                device=device,
+            )
+
+        output_hidden = self.draft_model(
+            position_ids=full_position_ids,
+            noise_embedding=noise_embedding,
+            target_hidden=hidden_states,
+            attention_mask=dflash_attn_mask,
+        )
+
+        logits = self.lm_head(output_hidden)
+
+        # Labels: position k predicts token at anchor+k
+        label_offsets = torch.arange(0, self.block_size, device=device).view(1, 1, -1)
+        label_indices = anchor_positions.unsqueeze(-1) + label_offsets
+        valid_label_mask = label_indices < seq_len
+        safe_label_indices = label_indices.clamp(max=seq_len - 1)
+
+        target_ids = torch.gather(
+            input_ids.unsqueeze(1).expand(-1, anchor_positions.size(1), -1),
+            2,
+            safe_label_indices,
+        )
+
+        # Weight mask: block validity * bounds * exclude anchor (pos 0) * loss_mask
+        weight_mask = block_keep_mask.unsqueeze(-1).expand(-1, -1, self.block_size).float()
+        weight_mask = weight_mask * valid_label_mask.float()
+
+        pos_in_block = torch.arange(self.block_size, device=device).view(1, 1, -1)
+        weight_mask = weight_mask * (pos_in_block > 0).float()
+
+        original_loss_mask_gathered = torch.gather(
+            loss_mask.unsqueeze(1).expand(-1, anchor_positions.size(1), -1),
+            2,
+            safe_label_indices,
+        )
+        weight_mask = weight_mask * original_loss_mask_gathered
+
+        binary_eval_mask = weight_mask.view(-1)
+
+        # Loss decay: exp(-(k-1)/gamma) so k=1 (1st prediction) gets weight 1.0
+        if self.loss_decay_gamma is not None and self.loss_decay_gamma > 0:
+            k = torch.arange(self.block_size, device=device).view(1, 1, -1)
+            decay_weights = torch.exp(-(k - 1).clamp(min=0).float() / self.loss_decay_gamma)
+            weight_mask = weight_mask * decay_weights
+
+        # Cross entropy
+        flat_logits = logits.view(-1, logits.size(-1))
+        flat_targets = target_ids.view(-1)
+        flat_weights = weight_mask.view(-1)
+
+        loss_per_token = F.cross_entropy(flat_logits, flat_targets, reduction="none")
+        valid_token_count = flat_weights.sum() + 1e-6
+        loss = (loss_per_token * flat_weights).sum() / valid_token_count
+
+        # Accuracy
+        with torch.no_grad():
+            pred_ids = torch.argmax(flat_logits, dim=-1)
+            correct = (pred_ids == flat_targets) & (binary_eval_mask > 0.5)
+            actual_token_count = binary_eval_mask.sum() + 1e-6
+            accuracy = correct.sum().float() / actual_token_count
+
+        return loss, accuracy

--- a/torchspec/models/draft/__init__.py
+++ b/torchspec/models/draft/__init__.py
@@ -18,14 +18,21 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from torchspec.models.draft.auto import AutoDraftModelConfig, AutoEagle3DraftModel
+from torchspec.models.draft.auto import (
+    AutoDFlashDraftModel,
+    AutoDraftModelConfig,
+    AutoEagle3DraftModel,
+)
 from torchspec.models.draft.base import Eagle3DraftModel
 from torchspec.models.draft.deepseek_eagle import Eagle3DeepseekV2ForCausalLM
+from torchspec.models.draft.dflash import DFlashDraftModel
 from torchspec.models.draft.llama3_eagle import LlamaForCausalLMEagle3
 
 __all__ = [
+    "AutoDFlashDraftModel",
     "AutoDraftModelConfig",
     "AutoEagle3DraftModel",
+    "DFlashDraftModel",
     "Eagle3DeepseekV2ForCausalLM",
     "Eagle3DraftModel",
     "LlamaForCausalLMEagle3",

--- a/torchspec/models/draft/auto.py
+++ b/torchspec/models/draft/auto.py
@@ -25,8 +25,10 @@ from typing import Union
 from transformers import AutoModelForCausalLM as AutoModelForCausalLMBase
 from transformers import LlamaConfig, PretrainedConfig, modeling_utils
 from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 
 from torchspec.models.draft.deepseek_eagle import Eagle3DeepseekV2ForCausalLM
+from torchspec.models.draft.dflash import DFlashDraftModel
 from torchspec.models.draft.llama3_eagle import LlamaForCausalLMEagle3
 from torchspec.utils.logging import logger
 
@@ -74,6 +76,7 @@ class AutoDraftModelConfig:
     _config_mapping = {
         "LlamaForCausalLMEagle3": LlamaConfig,
         "Eagle3DeepseekV2ForCausalLM": DeepseekV3Config,
+        "DFlashDraftModel": Qwen3Config,
     }
 
     @classmethod
@@ -107,3 +110,28 @@ class AutoDraftModelConfig:
         with open(config_path, "r") as f:
             config = json.load(f)
         return cls.from_dict(config)
+
+
+class AutoDFlashDraftModel:
+    """Auto-model factory for DFlash draft models.
+
+    Separate from AutoEagle3DraftModel — DFlash and Eagle3 are independent
+    architectures that must not share model factories.
+    """
+
+    _model_mapping = {
+        Qwen3Config: DFlashDraftModel,
+    }
+
+    @classmethod
+    def from_config(cls, config: PretrainedConfig, torch_dtype=None, **config_kwargs):
+        _model_cls = cls._model_mapping.get(type(config))
+        if _model_cls is None:
+            raise ValueError(
+                f"DFlash does not support config type {type(config).__name__}. "
+                f"Supported: {[c.__name__ for c in cls._model_mapping]}"
+            )
+        model = _model_cls(config, **config_kwargs)
+        if torch_dtype is not None:
+            model = model.to(dtype=torch_dtype)
+        return model

--- a/torchspec/models/draft/dflash.py
+++ b/torchspec/models/draft/dflash.py
@@ -1,0 +1,287 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""DFlash draft model for block diffusion speculative decoding.
+
+Architecture: Qwen3-based transformer layers with KV injection from target
+model context features. Non-causal (bidirectional) attention within blocks.
+"""
+
+from typing import Callable, List, Optional, Tuple
+
+import torch
+from torch import nn
+from transformers.cache_utils import Cache
+from transformers.models.qwen3.modeling_qwen3 import (
+    ALL_ATTENTION_FUNCTIONS,
+    FlashAttentionKwargs,
+    GradientCheckpointingLayer,
+    Qwen3Config,
+    Qwen3MLP,
+    Qwen3PreTrainedModel,
+    Qwen3RMSNorm,
+    Qwen3RotaryEmbedding,
+    eager_attention_forward,
+    rotate_half,
+)
+from typing_extensions import Unpack
+
+
+def build_target_layer_ids(num_target_layers: int, num_draft_layers: int) -> List[int]:
+    """Compute uniformly-spaced target layer indices for context feature extraction.
+
+    For 1 draft layer: returns the middle layer.
+    For N>1: linearly spaced from layer 1 to layer (num_target_layers - 3).
+    """
+    if num_draft_layers == 1:
+        return [num_target_layers // 2]
+    start = 1
+    end = num_target_layers - 3
+    span = end - start
+    return [
+        int(round(start + (i * span) / (num_draft_layers - 1))) for i in range(num_draft_layers)
+    ]
+
+
+def _apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_len = q.size(-2)
+    q_embed = (q * cos[..., -q_len:, :]) + (rotate_half(q) * sin[..., -q_len:, :])
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+class Qwen3DFlashAttention(nn.Module):
+    """Multi-head attention with KV injection from target context features.
+
+    Q is projected from draft hidden states only. K and V are projected from
+    both target_hidden (context features) and draft hidden_states (noise),
+    then concatenated: K = [K_ctx, K_noise], V = [V_ctx, V_noise].
+
+    Attention is non-causal (bidirectional within blocks).
+    """
+
+    def __init__(self, config: Qwen3Config, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
+        self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
+        self.scaling = self.head_dim**-0.5
+        self.attention_dropout = config.attention_dropout
+        self.is_causal = False
+
+        self.q_proj = nn.Linear(
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+        self.q_norm = Qwen3RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Qwen3RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.sliding_window = (
+            config.sliding_window if config.layer_types[layer_idx] == "sliding_attention" else None
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        target_hidden: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Cache] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        bsz, q_len = hidden_states.shape[:-1]
+        ctx_len = target_hidden.shape[1]
+
+        q = self.q_proj(hidden_states)
+        q = q.view(bsz, q_len, -1, self.head_dim)
+        q = self.q_norm(q).transpose(1, 2)
+
+        k_ctx = self.k_proj(target_hidden)
+        k_noise = self.k_proj(hidden_states)
+        v_ctx = self.v_proj(target_hidden)
+        v_noise = self.v_proj(hidden_states)
+
+        k = torch.cat([k_ctx, k_noise], dim=1).view(bsz, ctx_len + q_len, -1, self.head_dim)
+        v = torch.cat([v_ctx, v_noise], dim=1).view(bsz, ctx_len + q_len, -1, self.head_dim)
+        k = self.k_norm(k).transpose(1, 2)
+        v = v.transpose(1, 2)
+
+        cos, sin = position_embeddings
+        q, k = _apply_rotary_pos_emb(q, k, cos, sin)
+
+        if past_key_values is not None:
+            cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+            k, v = past_key_values.update(k, v, self.layer_idx, cache_kwargs)
+
+        attn_fn: Callable = eager_attention_forward
+        if self.config._attn_implementation != "eager":
+            attn_fn = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+        attn_output, attn_weights = attn_fn(
+            self,
+            q,
+            k,
+            v,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            sliding_window=self.sliding_window,
+            **kwargs,
+        )
+        attn_output = attn_output.reshape(bsz, q_len, -1)
+        attn_output = self.o_proj(attn_output)
+        return attn_output, attn_weights
+
+
+class Qwen3DFlashDecoderLayer(GradientCheckpointingLayer):
+    """Transformer decoder layer with DFlash KV injection."""
+
+    def __init__(self, config: Qwen3Config, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = Qwen3DFlashAttention(config=config, layer_idx=layer_idx)
+        self.mlp = Qwen3MLP(config)
+        self.input_layernorm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        target_hidden: Optional[torch.Tensor] = None,
+        hidden_states: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Cache] = None,
+        output_attentions: Optional[bool] = False,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states=hidden_states,
+            target_hidden=target_hidden,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )[0]
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class DFlashDraftModel(Qwen3PreTrainedModel):
+    """DFlash draft model for block diffusion speculative decoding.
+
+    Stacks N Qwen3DFlashDecoderLayer instances with KV injection from
+    target model context features. Features are projected via a linear
+    layer (fc) + RMSNorm before injection.
+
+    Does NOT inherit from Eagle3DraftModel — different architecture.
+    """
+
+    config_class = Qwen3Config
+    _no_split_modules = ["Qwen3DFlashDecoderLayer"]
+
+    def __init__(self, config: Qwen3Config) -> None:
+        super().__init__(config)
+        self.config = config
+        self.layers = nn.ModuleList(
+            [
+                Qwen3DFlashDecoderLayer(config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        dflash_config = getattr(config, "dflash_config", {}) or {}
+        explicit_layer_ids = dflash_config.get("target_layer_ids", None)
+        self.target_layer_ids = (
+            explicit_layer_ids
+            if explicit_layer_ids is not None
+            else build_target_layer_ids(config.num_target_layers, config.num_hidden_layers)
+        )
+        self.norm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Qwen3RotaryEmbedding(config)
+        self.fc = nn.Linear(
+            len(self.target_layer_ids) * config.hidden_size,
+            config.hidden_size,
+            bias=False,
+        )
+        self.hidden_norm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.block_size = config.block_size
+        self.mask_token_id = dflash_config.get("mask_token_id", None)
+        self.post_init()
+
+    def forward(
+        self,
+        position_ids: torch.LongTensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        noise_embedding: Optional[torch.Tensor] = None,
+        target_hidden: Optional[torch.Tensor] = None,
+        past_key_values: Optional[Cache] = None,
+        use_cache: bool = False,
+        **kwargs,
+    ) -> torch.Tensor:
+        hidden_states = noise_embedding
+        target_hidden = self.hidden_norm(self.fc(target_hidden))
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states=hidden_states,
+                target_hidden=target_hidden,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_value=past_key_values,
+                use_cache=use_cache,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+        return self.norm(hidden_states)

--- a/torchspec/models/target/target_utils.py
+++ b/torchspec/models/target/target_utils.py
@@ -232,3 +232,126 @@ class TargetLMHead(nn.Module):
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Compute logits from hidden states."""
         return self.lm_head(hidden_states)
+
+
+class TargetEmbeddingsAndHead(nn.Module):
+    """Loads frozen embed_tokens and lm_head from a pretrained target model.
+
+    Used by DFlash training which needs target embeddings for noise input
+    construction and the LM head for computing draft logits.
+
+    Handles weight tying (``tie_word_embeddings``) and multimodal models
+    with a ``text_config`` sub-config.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = getattr(config, "text_config", config)
+        self.embed_tokens = nn.Embedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            padding_idx=getattr(self.config, "pad_token_id", None),
+        )
+        self.lm_head = nn.Linear(self.config.hidden_size, self.config.vocab_size, bias=False)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_path: str,
+        embed_key: str = "model.embed_tokens.weight",
+        lm_head_key: str = "lm_head.weight",
+        cache_dir: Optional[str] = None,
+        device: str = "cuda",
+        dtype: torch.dtype = torch.bfloat16,
+        trust_remote_code: bool = False,
+    ) -> "TargetEmbeddingsAndHead":
+        config = AutoConfig.from_pretrained(
+            model_path, cache_dir=cache_dir, trust_remote_code=trust_remote_code
+        )
+        instance = cls(config)
+
+        local_model_path = model_path
+        if not os.path.exists(local_model_path):
+            try:
+                local_model_path = snapshot_download(repo_id=model_path, cache_dir=cache_dir)
+            except Exception:
+                pass
+
+        tie_weights = getattr(config, "tie_word_embeddings", False)
+        instance._load_weights(local_model_path, embed_key, lm_head_key, tie_weights)
+
+        instance.to(device=device, dtype=dtype)
+        instance.eval()
+        instance.requires_grad_(False)
+
+        return instance
+
+    def _load_weights(
+        self, model_path: str, embed_key: str, lm_head_key: str, tie_weights: bool
+    ) -> None:
+        index_files = glob.glob(os.path.join(model_path, "*.index.json"))
+        weight_map: dict = {}
+        files_to_load: dict = {}
+
+        if index_files:
+            with open(index_files[0], "r") as f:
+                index = json.load(f)
+            weight_map = index.get("weight_map", {})
+
+            if embed_key not in weight_map:
+                raise KeyError(
+                    f"Embedding key '{embed_key}' not found in weight_map. "
+                    f"Available keys: {list(weight_map.keys())[:10]}..."
+                )
+            files_to_load[embed_key] = weight_map[embed_key]
+
+            if not tie_weights:
+                if lm_head_key in weight_map:
+                    files_to_load[lm_head_key] = weight_map[lm_head_key]
+        else:
+            safetensors = glob.glob(os.path.join(model_path, "*.safetensors"))
+            bins = glob.glob(os.path.join(model_path, "*.bin"))
+            target_file = safetensors[0] if safetensors else (bins[0] if bins else None)
+            if not target_file:
+                raise FileNotFoundError(f"No checkpoint file found in {model_path}")
+            files_to_load[embed_key] = os.path.basename(target_file)
+            if not tie_weights:
+                files_to_load[lm_head_key] = os.path.basename(target_file)
+
+        # Group keys by file for efficient loading
+        file_to_keys: dict = {}
+        for key, filename in files_to_load.items():
+            full_path = os.path.join(model_path, filename)
+            file_to_keys.setdefault(full_path, []).append(key)
+
+        loaded_keys: set = set()
+        for file_path, keys in file_to_keys.items():
+            tensors = self._extract_tensors(file_path, keys)
+            for k, tensor in tensors.items():
+                if k == embed_key:
+                    self.embed_tokens.weight.data.copy_(tensor)
+                elif k == lm_head_key:
+                    self.lm_head.weight.data.copy_(tensor)
+                loaded_keys.add(k)
+
+        if tie_weights:
+            self.lm_head.weight = self.embed_tokens.weight
+
+        if embed_key not in loaded_keys:
+            raise RuntimeError(f"Failed to load embedding weights for key '{embed_key}'")
+
+    @staticmethod
+    def _extract_tensors(file_path: str, keys: list) -> dict:
+        result = {}
+        if file_path.endswith(".safetensors"):
+            with safe_open(file_path, framework="pt") as f:
+                for k in keys:
+                    if k in f.keys():
+                        result[k] = f.get_tensor(k)
+        else:
+            state_dict = torch.load(file_path, map_location="cpu")
+            for k in keys:
+                if k in state_dict:
+                    result[k] = state_dict[k]
+            del state_dict
+        return result

--- a/torchspec/train_entry.py
+++ b/torchspec/train_entry.py
@@ -191,8 +191,9 @@ def _get_draft_model_config(args):
 
 
 def train_async_no_generation(args):
-    """Entry point for Eagle3 online training.
+    """Entry point for speculative decoding online training.
 
+    Supports Eagle3 (default) and DFlash (draft_algorithm=dflash) training.
     Supports prefill-only mode (default) and decode mode (train_with_decode=True)
     with speculative decoding. Uses distributed Ray actors with placement groups.
     Engines store tensors in mooncake and return keys to AsyncInferenceManager.
@@ -202,6 +203,16 @@ def train_async_no_generation(args):
         and getattr(args, "inference_engine_type", "sgl") != "sgl"
     ):
         raise ValueError("train_with_decode=True requires inference_engine_type=sgl")
+
+    # DFlash-specific config validation
+    draft_algorithm = getattr(args, "draft_algorithm", "eagle3")
+    if draft_algorithm == "dflash":
+        if getattr(args, "inference_engine_type", "hf") != "sgl":
+            raise NotImplementedError("DFlash currently supports only inference_engine_type='sgl'.")
+        if not getattr(args, "draft_model_config", None):
+            raise ValueError("DFlash requires an explicit model.draft_model_config.")
+        if getattr(args, "defer_tokenization", False):
+            raise NotImplementedError("DFlash does not support defer_tokenization=True.")
 
     init_tracking(args)
     timer = _InitTimer()
@@ -214,6 +225,18 @@ def train_async_no_generation(args):
             scheduling_strategy=NodeAffinitySchedulingStrategy(node_id=driver_node_id, soft=False),
         ).remote(args, args.dp_size)
 
+    # [1.5] Parse draft config early — DFlash sample filter needs block_size
+    # before dataset loading starts. Safe to move here: _get_draft_model_config
+    # only reads args.draft_model_config (path) and args.target_model_path,
+    # both set during parse_config(). No downstream step depends on this
+    # happening after controller creation.
+    with timer.phase("Parse draft model config"):
+        draft_model_config = _get_draft_model_config(args)
+        args.draft_model_config_obj = draft_model_config
+        if draft_algorithm == "dflash":
+            block_size = getattr(draft_model_config, "block_size", 16)
+            args.dflash_min_loss_tokens = 2 * block_size
+
     # [2] Kick off dataset loading on controller (async — runs on actor while driver continues)
     timer.begin_async("Dataset loading")
     dataset_size_ref = controller.load_dataset.remote(args)
@@ -221,9 +244,6 @@ def train_async_no_generation(args):
 
     # [3] Do initialization that doesn't depend on dataset in parallel
     with timer.phase("Driver-side init"):
-        draft_model_config = _get_draft_model_config(args)
-        args.draft_model_config_obj = draft_model_config
-
         pgs = create_placement_groups(args)
         launch_mooncake_master(args)
         mooncake_config = build_mooncake_config(args)
@@ -239,10 +259,15 @@ def train_async_no_generation(args):
         auto_calculate_training_steps(args, dataset_size)
 
     # [6] Generate vocab mapping on controller if vocab pruning is enabled
+    #     (DFlash does not use vocab pruning)
     vocab_mapping = None
     draft_vocab_size = getattr(draft_model_config, "draft_vocab_size", None)
     vocab_size = draft_model_config.vocab_size
-    if draft_vocab_size is not None and draft_vocab_size != vocab_size:
+    if (
+        draft_algorithm != "dflash"
+        and draft_vocab_size is not None
+        and draft_vocab_size != vocab_size
+    ):
         with timer.phase("Vocab mapping"):
             logger.info(
                 f"Computing vocab mapping on controller "

--- a/torchspec/training/dflash_trainer.py
+++ b/torchspec/training/dflash_trainer.py
@@ -1,0 +1,322 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""DFlash-specific trainer.
+
+Extends ``Trainer`` with DFlash model initialisation, forward/backward,
+and metric aggregation.  Parallel to ``Eagle3Trainer`` — they share the
+base class but no model-specific logic.
+"""
+
+from argparse import Namespace
+from typing import Optional, Tuple
+
+import torch
+import torch.distributed as dist
+
+from torchspec.models.dflash import DFlashModel
+from torchspec.models.draft.dflash import DFlashDraftModel
+from torchspec.training import checkpoint
+from torchspec.training.fsdp import apply_fsdp2, fsdp2_load_full_state_dict
+from torchspec.training.optimizer import BF16Optimizer
+from torchspec.training.trainer import Trainer
+from torchspec.utils.distributed import get_gloo_group
+from torchspec.utils.logging import logger
+from torchspec.utils.tensor import padding
+
+
+class DFlashTrainer(Trainer):
+    """DFlash-specific trainer.
+
+    Extends ``Trainer`` with DFlash model initialisation, forward/backward,
+    and metric aggregation.
+    """
+
+    def __init__(self, args: Namespace):
+        super().__init__(args)
+        self._target_components: Optional[torch.nn.Module] = None
+
+    def init_model(
+        self,
+        draft_model_config,
+        target_model_path: str,
+        mooncake_config=None,
+    ) -> int:
+        if mooncake_config is not None:
+            from torchspec.transfer.mooncake.utils import (
+                check_mooncake_master_available,
+            )
+
+            check_mooncake_master_available(
+                mooncake_config.master_server_address, mooncake_config.metadata_server
+            )
+
+        init_context = self._get_init_weight_context_manager()
+
+        with init_context():
+            draft_model = DFlashDraftModel(draft_model_config)
+            draft_model = draft_model.to(dtype=torch.bfloat16)
+
+        dist.barrier(group=get_gloo_group())
+
+        trainable_count = sum(p.numel() for p in draft_model.parameters() if p.requires_grad)
+        frozen_count = sum(p.numel() for p in draft_model.parameters() if not p.requires_grad)
+        logger.info(
+            f"[Rank {self.dp_rank}] DFlash draft model: {trainable_count:,} trainable, "
+            f"{frozen_count:,} frozen parameters"
+        )
+
+        # Load frozen target embed_tokens + lm_head
+        self._init_target_components(target_model_path)
+
+        # DFlash config from draft model
+        block_size = getattr(draft_model_config, "block_size", 16)
+        dflash_config = getattr(draft_model_config, "dflash_config", {}) or {}
+        mask_token_id = dflash_config.get("mask_token_id", None)
+        if mask_token_id is None:
+            raise ValueError(
+                "mask_token_id must be set in draft model config's dflash_config section"
+            )
+
+        attention_backend = getattr(self.args, "attention_backend", "sdpa")
+        num_anchors = getattr(self.args, "dflash_num_anchors", 512)
+        loss_decay_gamma = getattr(self.args, "dflash_loss_decay_gamma", None)
+
+        dflash_model = DFlashModel(
+            draft_model=draft_model,
+            target_lm_head=self._target_components.lm_head,
+            target_embed_tokens=self._target_components.embed_tokens,
+            mask_token_id=mask_token_id,
+            block_size=block_size,
+            attention_backend=attention_backend,
+            num_anchors=num_anchors,
+            loss_decay_gamma=loss_decay_gamma,
+        )
+
+        full_state = dflash_model.state_dict() if dist.get_rank() == 0 else {}
+
+        dflash_model = apply_fsdp2(
+            dflash_model,
+            mesh=self.dp_mesh,
+            cpu_offload=self.fsdp_cpu_offload,
+            args=self.args,
+        )
+
+        dflash_model = fsdp2_load_full_state_dict(
+            dflash_model,
+            full_state,
+            self.dp_mesh,
+            cpu_offload=True if self.fsdp_cpu_offload else None,
+        )
+
+        self.model = dflash_model
+        self.draft_model = (
+            self.model.module.draft_model
+            if hasattr(self.model, "module")
+            else self.model.draft_model
+        )
+
+        decay_style = getattr(self.args, "lr_decay_style", "cosine")
+        wsd_decay_steps = None
+        wsd_decay_style = None
+        if decay_style == "WSD":
+            wsd_ratio = getattr(self.args, "lr_wsd_decay_ratio", 0.2)
+            wsd_decay_steps = int(wsd_ratio * self.args.lr_total_steps)
+            wsd_decay_style = getattr(self.args, "lr_wsd_decay_style", "cosine")
+        self.optimizer = BF16Optimizer(
+            self.draft_model,
+            lr=self.args.learning_rate,
+            max_grad_norm=self.args.max_grad_norm,
+            warmup_ratio=getattr(self.args, "warmup_ratio", 0.1),
+            total_steps=self.args.lr_total_steps,
+            decay_style=decay_style,
+            wsd_decay_steps=wsd_decay_steps,
+            wsd_decay_style=wsd_decay_style,
+        )
+        self.lr_scheduler = self.optimizer.lr_scheduler
+
+        checkpoint_payload = checkpoint.load(self)
+        checkpoint.finalize_load(self, checkpoint_payload)
+
+        self.prof.on_init_end()
+
+        logger.info(f"[Rank {self.dp_rank}] DFlash model initialized with FSDP2")
+
+        return 0
+
+    # ------------------------------------------------------------------
+    # Target component loading
+    # ------------------------------------------------------------------
+
+    def _init_target_components(self, target_model_path: str) -> None:
+        """Load frozen target embed_tokens + lm_head, broadcast to all ranks."""
+        from torchspec.models.target.target_utils import TargetEmbeddingsAndHead
+
+        if dist.get_rank() == 0:
+            self._target_components = TargetEmbeddingsAndHead.from_pretrained(
+                model_path=target_model_path,
+                embed_key=getattr(self.args, "embedding_key", "model.embed_tokens.weight"),
+                lm_head_key=getattr(self.args, "lm_head_key", "lm_head.weight"),
+                device="cuda",
+                dtype=torch.bfloat16,
+                trust_remote_code=getattr(self.args, "trust_remote_code", True),
+            )
+            logger.info(f"[Rank 0] TargetEmbeddingsAndHead loaded from {target_model_path}")
+        else:
+            from transformers import AutoConfig
+
+            config = AutoConfig.from_pretrained(
+                target_model_path,
+                trust_remote_code=getattr(self.args, "trust_remote_code", True),
+            )
+            self._target_components = TargetEmbeddingsAndHead(config)
+            self._target_components.to(device="cuda", dtype=torch.bfloat16)
+            self._target_components.eval()
+            self._target_components.requires_grad_(False)
+
+        dist.barrier()
+
+        for param in self._target_components.parameters():
+            dist.broadcast(param.data, src=0)
+
+        logger.info(f"[Rank {self.dp_rank}] TargetEmbeddingsAndHead initialized and synced")
+
+    # ------------------------------------------------------------------
+    # Forward / backward
+    # ------------------------------------------------------------------
+
+    def _forward(self, batch: dict) -> Tuple[torch.Tensor, torch.Tensor]:
+        input_ids = padding(batch["input_ids"], left=False).cuda()
+        hidden_states = padding(batch["hidden_states"], left=False).cuda()
+
+        loss_mask = batch["loss_mask"]
+        if loss_mask.dim() == 3:
+            loss_mask = loss_mask.squeeze(-1)
+        loss_mask = loss_mask.cuda()
+
+        loss, accuracy = self.model(
+            input_ids=input_ids,
+            hidden_states=hidden_states,
+            loss_mask=loss_mask,
+        )
+        return loss, accuracy
+
+    def _backward(self, loss: torch.Tensor, accumulation_steps: int = 1) -> torch.Tensor:
+        scaled_loss = loss / accumulation_steps
+        scaled_loss.backward()
+        return scaled_loss
+
+    # ------------------------------------------------------------------
+    # Eval
+    # ------------------------------------------------------------------
+
+    def eval_forward(self, batch: dict) -> dict:
+        with torch.no_grad():
+            loss, accuracy = self._forward(batch)
+        return {"loss": loss.detach(), "accuracy": accuracy.detach()}
+
+    def eval_from_cache(self) -> dict:
+        if not getattr(self, "_eval_cache", None):
+            return {}
+
+        eval_mbs = getattr(self.args, "eval_micro_batch_size", None) or self.args.micro_batch_size
+
+        self.model.eval()
+        all_metrics: list[dict] = []
+        for i in range(0, len(self._eval_cache), eval_mbs):
+            chunk = self._eval_cache[i : i + eval_mbs]
+            batch = self._eval_collator(chunk)
+            gpu_batch = {
+                k: v.cuda() if isinstance(v, torch.Tensor) else v for k, v in batch.items()
+            }
+            all_metrics.append(self.eval_forward(gpu_batch))
+
+        self.model.train()
+
+        return self._aggregate_eval_metrics(all_metrics)
+
+    def _aggregate_eval_metrics(self, all_step_metrics: list[dict]) -> dict:
+        if not all_step_metrics:
+            return {}
+
+        avg_loss = torch.stack([m["loss"] for m in all_step_metrics]).mean()
+        avg_acc = torch.stack([m["accuracy"] for m in all_step_metrics]).mean()
+
+        dist.all_reduce(avg_loss, op=dist.ReduceOp.AVG)
+        dist.all_reduce(avg_acc, op=dist.ReduceOp.AVG)
+
+        metrics = {
+            "eval/loss": avg_loss.item(),
+            "eval/accuracy": avg_acc.item(),
+        }
+
+        if dist.get_rank() == 0:
+            logger.info(f"eval: loss={avg_loss.item():.4f}, accuracy={avg_acc.item():.4f}")
+
+        return metrics
+
+    # ------------------------------------------------------------------
+    # Subclass contract implementations
+    # ------------------------------------------------------------------
+
+    def _train_step(
+        self,
+        batch: dict,
+        accumulation_steps: int,
+        step: int,
+        batch_idx: int,
+        num_batches: int,
+    ) -> dict:
+        loss, accuracy = self._forward(batch)
+        total_loss = self._backward(loss, accumulation_steps=accumulation_steps)
+
+        return {
+            "loss": loss.detach(),
+            "accuracy": accuracy.detach(),
+            "total_loss": total_loss.detach(),
+        }
+
+    def _aggregate_metrics(
+        self, all_step_metrics: list[dict], step: int, *, grad_norm: torch.Tensor = None
+    ) -> dict:
+        if not all_step_metrics:
+            return {}
+
+        avg_loss = torch.stack([m["loss"] for m in all_step_metrics]).mean()
+        avg_acc = torch.stack([m["accuracy"] for m in all_step_metrics]).mean()
+
+        dist.all_reduce(avg_loss, op=dist.ReduceOp.AVG)
+        dist.all_reduce(avg_acc, op=dist.ReduceOp.AVG)
+
+        metrics = {
+            "train/avg_loss": avg_loss.item(),
+            "train/avg_acc": avg_acc.item(),
+            "train/loss": avg_loss.item(),
+            "train/accuracy": avg_acc.item(),
+            "train/grad_norm": grad_norm.item() if grad_norm is not None else 0.0,
+            "train/global_step": self.global_step,
+            "train/lr": self.optimizer.get_learning_rate(),
+            "train/step": step,
+        }
+
+        if dist.get_rank() == 0:
+            logger.debug(f"step {step}: {metrics}")
+
+        return metrics

--- a/torchspec/training/trainer_actor.py
+++ b/torchspec/training/trainer_actor.py
@@ -26,7 +26,6 @@ import torch.distributed as dist
 
 from torchspec import AutoDraftModelConfig
 from torchspec.ray.ray_actor import RayActor
-from torchspec.training.eagle3_trainer import Eagle3Trainer
 from torchspec.utils.distributed import init_gloo_group
 from torchspec.utils.logging import setup_file_logging
 
@@ -64,7 +63,15 @@ class TrainerActor(RayActor):
         args.rank = dist.get_rank()
         args.world_size = dist.get_world_size()
 
-        self._trainer = Eagle3Trainer(args)
+        draft_algorithm = getattr(args, "draft_algorithm", "eagle3")
+        if draft_algorithm == "dflash":
+            from torchspec.training.dflash_trainer import DFlashTrainer
+
+            self._trainer = DFlashTrainer(args)
+        else:
+            from torchspec.training.eagle3_trainer import Eagle3Trainer
+
+            self._trainer = Eagle3Trainer(args)
 
         draft_model_config = getattr(args, "draft_model_config_obj", None)
         if draft_model_config is None and getattr(args, "draft_model_config", None):
@@ -99,7 +106,10 @@ class TrainerActor(RayActor):
         self._trainer.save_draft_model_for_serving(output_dir)
 
     def set_vocab_buffers(self, d2t, t2d) -> None:
-        self._trainer.draft_model.set_vocab_buffers(d2t, t2d)
+        if hasattr(self._trainer, "draft_model") and hasattr(
+            self._trainer.draft_model, "set_vocab_buffers"
+        ):
+            self._trainer.draft_model.set_vocab_buffers(d2t, t2d)
 
     def set_eval_queue(self, queue, mooncake_config=None, per_dp_rank_batch_size: int = 1):
         return self._trainer.set_eval_queue(


### PR DESCRIPTION
## Summary

- Implement DFlash (Block Diffusion for Flash Speculative Decoding) as a parallel training algorithm alongside Eagle3
- DFlash uses a lightweight block diffusion draft model that generates all tokens in a block via a single forward pass with non-causal attention and KV injection from target model context features
- Full integration with TorchSpec's disaggregated training pipeline: SGLang inference → Mooncake transfer → FSDP training

## Architecture

DFlash and Eagle3 are kept as **parallel, independent** training paths — they share the base `Trainer` class but no model-specific logic:

| Component | Eagle3 | DFlash |
|-----------|--------|--------|
| Draft model | `Eagle3DraftModel` (1 layer, causal) | `DFlashDraftModel` (N layers, non-causal KV injection) |
| Training wrapper | `Eagle3Model` (TTT loop, KL loss) | `DFlashModel` (parallel blocks, CE loss with decay) |
| Trainer | `Eagle3Trainer` | `DFlashTrainer` |
| Auto factory | `AutoEagle3DraftModel` | `AutoDFlashDraftModel` (separate) |

## New files (9)

- `torchspec/models/draft/dflash.py` — DFlash draft model (Qwen3-based, KV injection, bidirectional attention)
- `torchspec/models/dflash.py` — Training wrapper (anchor sampling, block-wise CE loss, flex_attention/SDPA masks)
- `torchspec/training/dflash_trainer.py` — Trainer with `TargetEmbeddingsAndHead`, FSDP2, DFlash metrics
- `torchspec/models/target/target_utils.py` — Added `TargetEmbeddingsAndHead` (frozen embed_tokens + lm_head)
- `configs/draft_models/qwen3_8b_dflash.json` — Qwen3-8B DFlash draft config (single source of truth)
- `configs/dflash_qwen3_8b.yaml` — Training config template
- `configs/dflash_qwen3_8b_e2e.yaml` — E2E test config (4 GPU)
- `examples/dflash-qwen3-8b-single-node/run.sh` — Launch script
- `tools/convert_dflash_to_hf.py` — FSDP checkpoint → HF safetensors export
- `tests/test_dflash.py` — 15 tests (mask precision, model forward, loss, dataflow, sample filter)

## Modified files (8)

- `sgl_engine.py` — DFlash layer capture from draft config, omit `last_hidden_states` from schema
- `train_entry.py` — Init ordering fix (draft config before dataset loading), DFlash validation, skip vocab pruning
- `trainer_actor.py` — Config-driven trainer dispatch (`draft_algorithm` field)
- `dataset.py` — DFlash min sample filter (`loss_mask >= 2*block_size`), cache key update
- `data/utils.py` — Relax collator validation for DFlash batches
- `auto.py` — `AutoDFlashDraftModel` + `AutoDraftModelConfig` DFlash mapping
- `train_config.py` — `draft_algorithm`, `dflash_num_anchors`, `dflash_loss_decay_gamma`
- Package `__init__.py` files — DFlash exports

## Scope & limitations (v1)

- SGLang inference backend only (HF/vLLM deferred)
- Qwen3 draft architecture only
- Requires explicit `model.draft_model_config`
- `defer_tokenization=True` not supported

## Test plan

- [x] 15 unit tests passing (CPU + NVIDIA B200 GPU)
  - Attention mask precision alignment with SpecForge reference implementation
  - `DFlashDraftModel` forward pass (no NaN/Inf, correct shapes)
  - `DFlashModel` loss + backward (valid loss, gradients flow)
  - `DataCollatorWithPadding` accepts DFlash samples (no `target`/`last_hidden_states`)
  - DFlash sample filter with `packed_loss_mask`
  - `build_target_layer_ids` consistency
- [x] E2E training on 4× B200: SGLang (tp=2) → Mooncake → DFlashTrainer (FSDP2, 2 GPU)
  - 50 steps with Qwen3-8B target, loss decreases from ~14 → ~5.5
  - Checkpoint saved successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)