### PR TITLE
Fix vLLM v0.19 MLA merge validation and CacheOnly KV cache registration

### DIFF
--- a/patches/vllm/v0.19.0/vllm.patch
+++ b/patches/vllm/v0.19.0/vllm.patch
@@ -10,6 +10,20 @@ TorchSpec patches for vllm v0.19.0
    vllm/transformers_utils/configs/extract_hidden_states.py
    (already in vllm >= 0.19.0, included here for older versions)
 
+4. Fix MLAAttentionSpec.merge() missing dimension validation
+   vllm/v1/kv_cache_interface.py
+   Without this, CacheOnlyAttentionLayer (used by extract_hidden_states)
+   gets incorrectly merged with MLA attention layers into a single uniform
+   KV cache group, causing the CacheOnly KV cache to be reshaped with MLA
+   dimensions (1 head, 576 dim) instead of hidden-state dimensions
+   (num_aux_layers heads, hidden_size dim).
+
+5. Register _CacheOnlyKVCacheSpec in the KV cache manager spec map
+   vllm/v1/core/single_type_kv_cache_manager.py
+   extract_hidden_states uses _CacheOnlyKVCacheSpec (a subclass of
+   AttentionSpec) which is not in vLLM's spec_manager_map, causing a
+   KeyError during engine init. Route it to FullAttentionManager.
+
 Apply:
   cd $VLLM_ROOT && git apply /path/to/vllm.patch
 
@@ -86,3 +100,62 @@ index 5391fbe1ad53..2beec0e3081b 100644
          super().__init__(**combined)
  
      @classmethod
+diff --git a/vllm/v1/kv_cache_interface.py b/vllm/v1/kv_cache_interface.py
+--- a/vllm/v1/kv_cache_interface.py
++++ b/vllm/v1/kv_cache_interface.py
+@@ -208,7 +208,7 @@
+ 
+     @classmethod
+     def merge(cls, specs: list[Self]) -> Self:
+         assert all(isinstance(spec, MLAAttentionSpec) for spec in specs), (
+             "All attention layers in the same KV cache group must be MLAAttentionSpec."
+         )
+         cache_dtype_str_set = set(spec.cache_dtype_str for spec in specs)
+@@ -216,7 +216,14 @@
+         assert len(cache_dtype_str_set) == 1, (
+             "All attention layers in the same KV cache group must use the same "
+             "quantization method."
+         )
+-        return cls(
++        merged = cls(
+             block_size=specs[0].block_size,
+             num_kv_heads=specs[0].num_kv_heads,
+             head_size=specs[0].head_size,
+@@ -224,3 +224,10 @@
+             dtype=specs[0].dtype,
+             page_size_padded=specs[0].page_size_padded,
+             cache_dtype_str=cache_dtype_str_set.pop(),
+-        )
++        )
++        for spec in specs:
++            for f in fields(AttentionSpec):
++                assert getattr(spec, f.name) == getattr(merged, f.name), (
++                    "All MLAAttentionSpec layers in the same KV cache group "
++                    f"must match on {f.name}: "
++                    f"{getattr(spec, f.name)} != {getattr(merged, f.name)}"
++                )
++        return merged
+diff --git a/vllm/v1/core/single_type_kv_cache_manager.py b/vllm/v1/core/single_type_kv_cache_manager.py
+--- a/vllm/v1/core/single_type_kv_cache_manager.py
++++ b/vllm/v1/core/single_type_kv_cache_manager.py
+@@ -1109,6 +1109,14 @@
+ spec_manager_map: dict[type[KVCacheSpec], type[SingleTypeKVCacheManager]] = {
+     FullAttentionSpec: FullAttentionManager,
+     MLAAttentionSpec: FullAttentionManager,
+     SlidingWindowSpec: SlidingWindowManager,
+     ChunkedLocalAttentionSpec: ChunkedLocalAttentionManager,
+     MambaSpec: MambaManager,
+     CrossAttentionSpec: CrossAttentionManager,
+     SinkFullAttentionSpec: SinkFullAttentionManager,
+ }
+ 
++try:
++    from vllm.model_executor.models.extract_hidden_states import (
++        _CacheOnlyKVCacheSpec,
++    )
++    spec_manager_map[_CacheOnlyKVCacheSpec] = FullAttentionManager
++except ImportError:
++    pass
++
+ 
+ def get_manager_for_kv_cache_spec(

--- a/tests/test_vllm_engine_integration.py
+++ b/tests/test_vllm_engine_integration.py
@@ -64,6 +64,9 @@ def create_engine(
     tp_size: int,
     aux_layer_ids: list[int],
     max_num_batched_tokens: int | None = None,
+    enforce_eager: bool = False,
+    load_format: str | None = None,
+    max_model_len: int = 4096,
 ):
     from vllm import LLM
 
@@ -81,7 +84,9 @@ def create_engine(
         disable_custom_all_reduce=True,
         disable_log_stats=True,
         enable_prefix_caching=False,
-        max_model_len=4096,
+        max_model_len=max_model_len,
+        enforce_eager=enforce_eager,
+        **({"load_format": load_format} if load_format else {}),
         speculative_config={
             "method": "extract_hidden_states",
             "num_speculative_tokens": 1,
@@ -214,9 +219,13 @@ def run_test(
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model", default="Qwen/Qwen3-8B")
-    parser.add_argument("--tp", type=int, default=4)
+    parser.add_argument("--model", default="moonshotai/Kimi-K2.5")
+    parser.add_argument("--tp", type=int, default=8)
     parser.add_argument("--dump-dir", default="./tensor_dumps")
+    parser.add_argument("--load-format", default="fastsafetensors")
+    parser.add_argument("--enforce-eager", action="store_true", default=True)
+    parser.add_argument("--no-enforce-eager", dest="enforce_eager", action="store_false")
+    parser.add_argument("--max-model-len", type=int, default=4096)
     parser.add_argument(
         "--aux-layers",
         type=int,
@@ -245,6 +254,9 @@ def main():
 
     print(f"Model:           {args.model}")
     print(f"TP size:         {args.tp}")
+    print(f"Load format:     {args.load_format}")
+    print(f"Enforce eager:   {args.enforce_eager}")
+    print(f"Max model len:   {args.max_model_len}")
     print(f"Aux layer IDs:   {aux_layer_ids}")
     print(f"  training layers: {aux_layer_ids[:-1]} -> hidden_dim={hidden_dim}")
     print(f"  final layer:     {aux_layer_ids[-1]} -> last_hidden_dim={last_hidden_dim}")
@@ -263,7 +275,14 @@ def main():
     }
     torch.save(meta, dump_dir / "vllm_meta.pt")
 
-    engine = create_engine(args.model, args.tp, aux_layer_ids)
+    engine = create_engine(
+        args.model,
+        args.tp,
+        aux_layer_ids,
+        enforce_eager=args.enforce_eager,
+        load_format=args.load_format,
+        max_model_len=args.max_model_len,
+    )
 
     from torchspec.transfer.mooncake import EagleMooncakeStore, MooncakeConfig
 
@@ -349,6 +368,9 @@ def main():
         args.tp,
         aux_layer_ids,
         max_num_batched_tokens=128,
+        enforce_eager=args.enforce_eager,
+        load_format=args.load_format,
+        max_model_len=args.max_model_len,
     )
 
     # Sequences longer than 128 tokens will require multiple prefill chunks.


### PR DESCRIPTION
## Summary
- **MLAAttentionSpec.merge() dimension validation**: Without this fix, `CacheOnlyAttentionLayer` (used by `extract_hidden_states`) gets incorrectly merged with MLA attention layers into a single KV cache group, causing the CacheOnly KV cache to be reshaped with MLA dimensions (1 head, 576 dim) instead of hidden-state dimensions (`num_aux_layers` heads, `hidden_size` dim).
- **Register `_CacheOnlyKVCacheSpec` in `spec_manager_map`**: `extract_hidden_states` uses `_CacheOnlyKVCacheSpec` (a subclass of `AttentionSpec`) which is not in vLLM's `spec_manager_map`, causing a `KeyError` during engine init. Routes it to `FullAttentionManager`.
- **Integration test improvements**: Update defaults to Kimi-K2.5 model, add CLI flags for `--load-format`, `--enforce-eager`, and `--max-model-len`.

## Test plan
- [ ] Run vLLM engine integration test with Kimi-K2.5 and verify engine init succeeds without KeyError
- [ ] Verify MLA and CacheOnly layers are placed in separate KV cache groups