### PR TITLE
DFlash: enable eval_from_cache + per-position (per-k) train/eval metrics

### DIFF
--- a/configs/dflash_qwen3_8b_repro.yaml
+++ b/configs/dflash_qwen3_8b_repro.yaml
@@ -65,6 +65,10 @@ mooncake:
   protocol: tcp
   global_segment_size: 16GB
   local_buffer_size: 4GB
+  # Hard-pin: master-side TTL is disabled; we rely on our explicit
+  # batch_remove(force=True) (see mooncake/eagle_store.py). Requires
+  # mooncake-transfer-engine >= 0.3.10.post1.
+  enable_hard_pin: true
 
 output_dir: ./outputs/dflash_repro
 cache_dir: ./cache/dflash_repro

--- a/configs/sglang_qwen3_8b_dflash.yaml
+++ b/configs/sglang_qwen3_8b_dflash.yaml
@@ -75,6 +75,10 @@ mooncake:
   protocol: tcp
   global_segment_size: 16GB
   local_buffer_size: 4GB
+  # Hard-pin: master-side TTL is disabled; we rely on our explicit
+  # batch_remove(force=True) (see mooncake/eagle_store.py). Requires
+  # mooncake-transfer-engine >= 0.3.10.post1.
+  enable_hard_pin: true
 
 output_dir: ./outputs/qwen3-8b-dflash
 cache_dir: ./cache/qwen3-8b-dflash

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -415,7 +415,7 @@ class TestDFlashModelForward(unittest.TestCase):
         lm_head_weight = torch.randn(self.V, self.H)
 
         with torch.no_grad():
-            loss, acc = self.model(
+            loss, acc, loss_pp, acc_pp = self.model(
                 input_ids=input_ids,
                 hidden_states_list=hidden_states_list,
                 loss_mask=loss_mask,
@@ -426,6 +426,8 @@ class TestDFlashModelForward(unittest.TestCase):
         self.assertGreaterEqual(loss.item(), 0.0)
         self.assertGreaterEqual(acc.item(), 0.0)
         self.assertLessEqual(acc.item(), 1.0)
+        self.assertEqual(loss_pp.shape, (self.model.block_size,))
+        self.assertEqual(acc_pp.shape, (self.model.block_size,))
 
     def test_loss_requires_grad(self):
         """Loss should be differentiable through the draft model."""
@@ -438,7 +440,7 @@ class TestDFlashModelForward(unittest.TestCase):
         lm_head_weight = torch.randn(self.V, self.H)
 
         self.model.train()
-        loss, acc = self.model(
+        loss, acc, _, _ = self.model(
             input_ids=input_ids,
             hidden_states_list=hidden_states_list,
             loss_mask=loss_mask,
@@ -471,7 +473,7 @@ class TestDFlashModelForward(unittest.TestCase):
         # All valid
         loss_mask_full = torch.ones(B, seq_len)
         with torch.no_grad():
-            loss_full, _ = self.model(
+            loss_full, *_ = self.model(
                 input_ids=input_ids,
                 hidden_states_list=hidden_states_list,
                 loss_mask=loss_mask_full,
@@ -482,7 +484,7 @@ class TestDFlashModelForward(unittest.TestCase):
         loss_mask_half = torch.ones(B, seq_len)
         loss_mask_half[:, :32] = 0.0
         with torch.no_grad():
-            loss_half, _ = self.model(
+            loss_half, *_ = self.model(
                 input_ids=input_ids,
                 hidden_states_list=hidden_states_list,
                 loss_mask=loss_mask_half,
@@ -563,7 +565,7 @@ class TestMiniTrainingLoop(unittest.TestCase):
         losses = []
         for step in range(10):
             optimizer.zero_grad()
-            loss, acc = model(
+            loss, acc, _, _ = model(
                 input_ids=input_ids,
                 hidden_states_list=hidden_states_list,
                 loss_mask=loss_mask,
@@ -591,7 +593,7 @@ class TestMiniTrainingLoop(unittest.TestCase):
 
         model.train()
         model.zero_grad()
-        loss1, _ = model(
+        loss1, *_ = model(
             input_ids=input_ids,
             hidden_states_list=hidden_states_list,
             loss_mask=loss_mask,
@@ -599,7 +601,7 @@ class TestMiniTrainingLoop(unittest.TestCase):
         )
         (loss1 / 2).backward()
 
-        loss2, _ = model(
+        loss2, *_ = model(
             input_ids=input_ids,
             hidden_states_list=hidden_states_list,
             loss_mask=loss_mask,
@@ -896,7 +898,7 @@ class TestDFlashTrainingQuality(unittest.TestCase):
         losses, accs = [], []
         for _ in range(steps):
             optimizer.zero_grad()
-            loss, acc = model(
+            loss, acc, _, _ = model(
                 input_ids=input_ids,
                 hidden_states_list=hidden_states_list,
                 loss_mask=loss_mask,
@@ -946,7 +948,7 @@ class TestDFlashTrainingQuality(unittest.TestCase):
         grad_norms = []
         for _ in range(10):
             optimizer.zero_grad()
-            loss, _ = model(
+            loss, *_ = model(
                 input_ids=input_ids,
                 hidden_states_list=hs_list,
                 loss_mask=mask,
@@ -1035,7 +1037,7 @@ class TestDFlashVsEagle3Architecture(unittest.TestCase):
         lm_head_weight = torch.randn(V, H)
 
         with torch.no_grad():
-            loss, acc = model(
+            loss, acc, _, _ = model(
                 input_ids=input_ids,
                 hidden_states_list=hs_list,
                 loss_mask=loss_mask,

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -10,6 +10,7 @@ Covers:
 
 import math
 import unittest
+from unittest import mock
 
 import torch
 
@@ -415,7 +416,7 @@ class TestDFlashModelForward(unittest.TestCase):
         lm_head_weight = torch.randn(self.V, self.H)
 
         with torch.no_grad():
-            loss, acc, loss_pp, acc_pp = self.model(
+            loss, acc, loss_pp, acc_pp, count_pp = self.model(
                 input_ids=input_ids,
                 hidden_states_list=hidden_states_list,
                 loss_mask=loss_mask,
@@ -428,6 +429,7 @@ class TestDFlashModelForward(unittest.TestCase):
         self.assertLessEqual(acc.item(), 1.0)
         self.assertEqual(loss_pp.shape, (self.model.block_size,))
         self.assertEqual(acc_pp.shape, (self.model.block_size,))
+        self.assertEqual(count_pp.shape, (self.model.block_size,))
 
     def test_loss_requires_grad(self):
         """Loss should be differentiable through the draft model."""
@@ -440,7 +442,7 @@ class TestDFlashModelForward(unittest.TestCase):
         lm_head_weight = torch.randn(self.V, self.H)
 
         self.model.train()
-        loss, acc, _, _ = self.model(
+        loss, acc, _, _, _ = self.model(
             input_ids=input_ids,
             hidden_states_list=hidden_states_list,
             loss_mask=loss_mask,
@@ -542,6 +544,92 @@ class TestDFlashModelForward(unittest.TestCase):
             self.assertEqual(anchor_weight[0, 0, i].item(), 1.0)
 
 
+class TestDFlashTrainerAggregation(unittest.TestCase):
+    class _DummyOptimizer:
+        def get_learning_rate(self):
+            return 1e-3
+
+    @staticmethod
+    def _make_trainer():
+        from torchspec.training.dflash_trainer import DFlashTrainer
+
+        trainer = object.__new__(DFlashTrainer)
+        trainer.loss_decay_gamma = 1.0
+        trainer.global_step = 7
+        trainer.optimizer = TestDFlashTrainerAggregation._DummyOptimizer()
+        return trainer
+
+    @staticmethod
+    def _step_metrics(loss_key: str, acc_key: str, count_key: str) -> list[dict]:
+        return [
+            {
+                loss_key: torch.tensor([0.0, 1.0, 5.0, 0.0]),
+                acc_key: torch.tensor([0.0, 0.5, 1.0, 0.0]),
+                count_key: torch.tensor([0.0, 10.0, 2.0, 0.0]),
+            },
+            {
+                loss_key: torch.tensor([0.0, 0.0, 2.0, 4.0]),
+                acc_key: torch.tensor([0.0, 0.0, 0.25, 0.5]),
+                count_key: torch.tensor([0.0, 0.0, 8.0, 4.0]),
+            },
+        ]
+
+    @staticmethod
+    def _expected_avg_loss() -> float:
+        counts = [10.0, 10.0, 4.0]
+        losses = [1.0, 2.6, 4.0]
+        weights = [math.exp(-i) for i in range(len(losses))]
+        numerator = sum(losses[i] * counts[i] * weights[i] for i in range(len(losses)))
+        denominator = sum(counts[i] * weights[i] for i in range(len(losses)))
+        return numerator / denominator
+
+    @mock.patch("torchspec.training.dflash_trainer.dist.get_rank", return_value=0)
+    @mock.patch(
+        "torchspec.training.dflash_trainer.dist.all_reduce",
+        side_effect=lambda tensor, op=None: None,
+    )
+    def test_aggregate_metrics_uses_per_position_counts(self, _mock_all_reduce, _mock_get_rank):
+        trainer = self._make_trainer()
+        metrics = trainer._aggregate_metrics(
+            self._step_metrics("loss_per_position", "acc_per_position", "count_per_position"),
+            step=11,
+            grad_norm=torch.tensor(3.0),
+        )
+
+        self.assertAlmostEqual(metrics["train/ploss_0"], 1.0, places=6)
+        self.assertAlmostEqual(metrics["train/ploss_1"], 2.6, places=6)
+        self.assertAlmostEqual(metrics["train/ploss_2"], 4.0, places=6)
+        self.assertAlmostEqual(metrics["train/acc_0"], 0.5, places=6)
+        self.assertAlmostEqual(metrics["train/acc_1"], 0.4, places=6)
+        self.assertAlmostEqual(metrics["train/acc_2"], 0.5, places=6)
+        self.assertAlmostEqual(metrics["train/avg_acc"], 11.0 / 24.0, places=6)
+        self.assertAlmostEqual(metrics["train/avg_loss"], self._expected_avg_loss(), places=6)
+        self.assertAlmostEqual(metrics["train/simulated_acc_len"], 0.8, places=6)
+
+    @mock.patch("torchspec.training.dflash_trainer.dist.get_rank", return_value=0)
+    @mock.patch(
+        "torchspec.training.dflash_trainer.dist.all_reduce",
+        side_effect=lambda tensor, op=None: None,
+    )
+    def test_aggregate_eval_metrics_uses_exact_scalar_reduction(
+        self, _mock_all_reduce, _mock_get_rank
+    ):
+        trainer = self._make_trainer()
+        metrics = trainer._aggregate_eval_metrics(
+            self._step_metrics("loss_pp", "acc_pp", "count_pp")
+        )
+
+        self.assertAlmostEqual(metrics["eval/ploss_0"], 1.0, places=6)
+        self.assertAlmostEqual(metrics["eval/ploss_1"], 2.6, places=6)
+        self.assertAlmostEqual(metrics["eval/ploss_2"], 4.0, places=6)
+        self.assertAlmostEqual(metrics["eval/acc_0"], 0.5, places=6)
+        self.assertAlmostEqual(metrics["eval/acc_1"], 0.4, places=6)
+        self.assertAlmostEqual(metrics["eval/acc_2"], 0.5, places=6)
+        self.assertAlmostEqual(metrics["eval/avg_acc"], 11.0 / 24.0, places=6)
+        self.assertAlmostEqual(metrics["eval/avg_loss"], self._expected_avg_loss(), places=6)
+        self.assertAlmostEqual(metrics["eval/simulated_acc_len"], 0.8, places=6)
+
+
 class TestMiniTrainingLoop(unittest.TestCase):
     """Smoke test: forward → backward → optimizer step should not crash and loss should decrease."""
 
@@ -565,7 +653,7 @@ class TestMiniTrainingLoop(unittest.TestCase):
         losses = []
         for step in range(10):
             optimizer.zero_grad()
-            loss, acc, _, _ = model(
+            loss, acc, _, _, _ = model(
                 input_ids=input_ids,
                 hidden_states_list=hidden_states_list,
                 loss_mask=loss_mask,
@@ -898,7 +986,7 @@ class TestDFlashTrainingQuality(unittest.TestCase):
         losses, accs = [], []
         for _ in range(steps):
             optimizer.zero_grad()
-            loss, acc, _, _ = model(
+            loss, acc, _, _, _ = model(
                 input_ids=input_ids,
                 hidden_states_list=hidden_states_list,
                 loss_mask=loss_mask,
@@ -1037,7 +1125,7 @@ class TestDFlashVsEagle3Architecture(unittest.TestCase):
         lm_head_weight = torch.randn(V, H)
 
         with torch.no_grad():
-            loss, acc, _, _ = model(
+            loss, acc, _, _, _ = model(
                 input_ids=input_ids,
                 hidden_states_list=hs_list,
                 loss_mask=loss_mask,

--- a/torchspec/models/dflash.py
+++ b/torchspec/models/dflash.py
@@ -215,7 +215,7 @@ class DFlashModel(nn.Module):
         hidden_states_list: List[torch.Tensor],
         loss_mask: torch.Tensor,
         lm_head_weight: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Full DFlash training forward pass.
 
         Matches SpecForge's OnlineDFlashModel.forward().
@@ -227,6 +227,8 @@ class DFlashModel(nn.Module):
                 (index 0 is the anchor slot and always 0; indices 1..B-1 are the
                 predicted tokens at 1..B-1 steps past the anchor)
             acc_per_position: [block_size] mean accuracy at each within-block position
+            count_per_position: [block_size] valid label count at each within-block
+                position before loss decay is applied
         """
         bsz, seq_len = input_ids.shape
         device = input_ids.device
@@ -332,21 +334,22 @@ class DFlashModel(nn.Module):
         flat_weights = weight_mask.view(-1)
 
         loss_per_token = F.cross_entropy(flat_logits, flat_targets, reduction="none")
-        valid_token_count = flat_weights.sum() + 1e-6
+        valid_token_count = flat_weights.sum().clamp(min=1e-6)
         loss = (loss_per_token * flat_weights).sum() / valid_token_count
 
         # 10. Accuracy (using binary mask without decay)
         with torch.no_grad():
             pred_ids = torch.argmax(flat_logits, dim=-1)
             correct = (pred_ids == flat_targets) & (binary_eval_mask > 0.5)
-            actual_token_count = binary_eval_mask.sum() + 1e-6
+            actual_token_count = binary_eval_mask.sum().clamp(min=1e-6)
             accuracy = correct.sum().float() / actual_token_count
 
             # Per-position-within-block metrics (index 0 = anchor, masked out;
             # indices 1..block_size-1 correspond to 1..B-1 tokens past the anchor).
             # Matches Eagle3's per-TTT-position breakdown semantically.
             binary_weights = binary_eval_mask.view(bsz, n_blocks, self.block_size)
-            count_per_pos = binary_weights.sum(dim=(0, 1)).clamp(min=1.0)
+            count_per_position = binary_weights.sum(dim=(0, 1))
+            count_per_pos = count_per_position.clamp(min=1.0)
 
             loss_per_position = (
                 loss_per_token.view(bsz, n_blocks, self.block_size) * binary_weights
@@ -355,4 +358,4 @@ class DFlashModel(nn.Module):
                 dim=(0, 1)
             ) / count_per_pos
 
-        return loss, accuracy, loss_per_position, acc_per_position
+        return loss, accuracy, loss_per_position, acc_per_position, count_per_position

--- a/torchspec/models/dflash.py
+++ b/torchspec/models/dflash.py
@@ -215,10 +215,18 @@ class DFlashModel(nn.Module):
         hidden_states_list: List[torch.Tensor],
         loss_mask: torch.Tensor,
         lm_head_weight: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Full DFlash training forward pass.
 
         Matches SpecForge's OnlineDFlashModel.forward().
+
+        Returns:
+            loss: scalar training loss (decay-weighted)
+            accuracy: scalar accuracy (binary mask, no decay)
+            loss_per_position: [block_size] mean loss at each within-block position
+                (index 0 is the anchor slot and always 0; indices 1..B-1 are the
+                predicted tokens at 1..B-1 steps past the anchor)
+            acc_per_position: [block_size] mean accuracy at each within-block position
         """
         bsz, seq_len = input_ids.shape
         device = input_ids.device
@@ -334,4 +342,17 @@ class DFlashModel(nn.Module):
             actual_token_count = binary_eval_mask.sum() + 1e-6
             accuracy = correct.sum().float() / actual_token_count
 
-        return loss, accuracy
+            # Per-position-within-block metrics (index 0 = anchor, masked out;
+            # indices 1..block_size-1 correspond to 1..B-1 tokens past the anchor).
+            # Matches Eagle3's per-TTT-position breakdown semantically.
+            binary_weights = binary_eval_mask.view(bsz, n_blocks, self.block_size)
+            count_per_pos = binary_weights.sum(dim=(0, 1)).clamp(min=1.0)
+
+            loss_per_position = (
+                loss_per_token.view(bsz, n_blocks, self.block_size) * binary_weights
+            ).sum(dim=(0, 1)) / count_per_pos
+            acc_per_position = (correct.view(bsz, n_blocks, self.block_size).float()).sum(
+                dim=(0, 1)
+            ) / count_per_pos
+
+        return loss, accuracy, loss_per_position, acc_per_position

--- a/torchspec/training/dflash_trainer.py
+++ b/torchspec/training/dflash_trainer.py
@@ -251,7 +251,9 @@ class DFlashTrainer(Trainer):
         per_layer_dim = total_dim // self.num_target_layers
         return list(hidden_states.split(per_layer_dim, dim=-1))
 
-    def _forward(self, batch: dict) -> Tuple[torch.Tensor, torch.Tensor]:
+    def _forward(
+        self, batch: dict
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         device = torch.device("cuda")
         input_ids = batch["input_ids"].to(device, non_blocking=True)
         hidden_states = batch["hidden_states"].to(device, non_blocking=True)
@@ -264,14 +266,14 @@ class DFlashTrainer(Trainer):
         hidden_states_list = self._split_hidden_states(hidden_states)
         del hidden_states
 
-        loss, accuracy = self.model(
+        loss, accuracy, loss_per_position, acc_per_position = self.model(
             input_ids=input_ids,
             hidden_states_list=hidden_states_list,
             loss_mask=loss_mask,
             lm_head_weight=self.target_lm_head_weight,
         )
 
-        return loss, accuracy
+        return loss, accuracy, loss_per_position, acc_per_position
 
     def _backward(self, loss: torch.Tensor, accumulation_steps: int = 1) -> torch.Tensor:
         scaled_loss = loss / accumulation_steps
@@ -279,12 +281,93 @@ class DFlashTrainer(Trainer):
         return loss
 
     # ------------------------------------------------------------------
-    # Eval — disabled for DFlash (eval hangs in colocate/SGLang mode;
-    # benchmark τ separately after training via scripts/modal/modal_dflash_benchmark_sglang.py)
+    # Eval (no-grad forward on CPU-cached data) — mirrors Eagle3Trainer
     # ------------------------------------------------------------------
 
+    def eval_forward(self, batch: dict) -> dict:
+        """Single forward pass without backward — returns per-position tensors."""
+        with torch.no_grad():
+            _, _, loss_per_position, acc_per_position = self._forward(batch)
+        return {
+            "loss_pp": loss_per_position.detach(),
+            "acc_pp": acc_per_position.detach(),
+        }
+
     def eval_from_cache(self) -> dict:
-        return {}
+        """Run forward-only eval over all CPU-cached eval samples.
+
+        Samples are stored individually (no padding). Re-collate into batches
+        of ``eval_micro_batch_size`` (or ``micro_batch_size``) so the eval
+        forward batch size is independent of cache generation throughput.
+        """
+        if not getattr(self, "_eval_cache", None):
+            return {}
+
+        eval_mbs = getattr(self.args, "eval_micro_batch_size", None) or self.args.micro_batch_size
+
+        self.model.eval()
+        all_metrics: list[dict] = []
+        for i in range(0, len(self._eval_cache), eval_mbs):
+            chunk = self._eval_cache[i : i + eval_mbs]
+            batch = self._eval_collator(chunk)
+            gpu_batch = {
+                k: v.cuda() if isinstance(v, torch.Tensor) else v for k, v in batch.items()
+            }
+            all_metrics.append(self.eval_forward(gpu_batch))
+
+        self.model.train()
+
+        return self._aggregate_eval_metrics(all_metrics)
+
+    def _aggregate_eval_metrics(self, all_step_metrics: list[dict]) -> dict:
+        if not all_step_metrics:
+            return {}
+
+        avg_loss_pp = torch.stack([m["loss_pp"] for m in all_step_metrics]).mean(dim=0)
+        avg_acc_pp = torch.stack([m["acc_pp"] for m in all_step_metrics]).mean(dim=0)
+
+        dist.all_reduce(avg_loss_pp, op=dist.ReduceOp.AVG)
+        dist.all_reduce(avg_acc_pp, op=dist.ReduceOp.AVG)
+
+        # Drop anchor slot (index 0) — see _aggregate_metrics for rationale.
+        pred_loss_pp = avg_loss_pp[1:]
+        pred_acc_pp = avg_acc_pp[1:]
+
+        cumulative = 1.0
+        simulated_acc_len = 0.0
+        for i in range(pred_acc_pp.shape[0]):
+            cumulative *= pred_acc_pp[i].item()
+            simulated_acc_len += cumulative
+
+        # Weighted avg loss using the same decay as the training objective,
+        # so eval/avg_loss is directly comparable to train/avg_loss.
+        gamma = self.loss_decay_gamma
+        if gamma is not None and gamma > 0:
+            k = torch.arange(pred_loss_pp.shape[0], device=pred_loss_pp.device)
+            # In forward, position-in-block k has weight exp(-(k-1)/gamma) for k>=1.
+            # After slicing away index 0, predicted index i corresponds to k=i+1,
+            # so weights become exp(-i/gamma).
+            weights = torch.exp(-k.float() / gamma)
+        else:
+            weights = torch.ones_like(pred_loss_pp)
+        weighted_avg_loss = (pred_loss_pp * weights).sum().item() / weights.sum().item()
+
+        metrics: dict = {
+            "eval/avg_loss": weighted_avg_loss,
+            "eval/avg_acc": pred_acc_pp.mean().item(),
+            "eval/simulated_acc_len": simulated_acc_len,
+        }
+        for i in range(pred_loss_pp.shape[0]):
+            metrics[f"eval/ploss_{i}"] = pred_loss_pp[i].item()
+            metrics[f"eval/acc_{i}"] = pred_acc_pp[i].item()
+
+        if dist.get_rank() == 0:
+            logger.info(
+                f"eval: loss={weighted_avg_loss:.4f}, acc={pred_acc_pp.mean().item():.4f}, "
+                f"sim_acc_len={simulated_acc_len:.2f}"
+            )
+
+        return metrics
 
     # ------------------------------------------------------------------
     # Subclass contract implementations
@@ -304,7 +387,7 @@ class DFlashTrainer(Trainer):
         evt_bwd_e = torch.cuda.Event(enable_timing=True)
 
         evt_fwd_s.record()
-        loss, accuracy = self._forward(batch)
+        loss, accuracy, loss_per_position, acc_per_position = self._forward(batch)
         evt_fwd_e.record()
 
         evt_bwd_s.record()
@@ -314,6 +397,8 @@ class DFlashTrainer(Trainer):
         return {
             "loss": loss.detach(),
             "accuracy": accuracy.detach(),
+            "loss_per_position": loss_per_position.detach(),
+            "acc_per_position": acc_per_position.detach(),
             "total_loss": total_loss.detach(),
             "_fwd_events": (evt_fwd_s, evt_fwd_e),
             "_bwd_events": (evt_bwd_s, evt_bwd_e),
@@ -327,18 +412,41 @@ class DFlashTrainer(Trainer):
 
         avg_loss = torch.stack([m["loss"] for m in all_step_metrics]).mean()
         avg_acc = torch.stack([m["accuracy"] for m in all_step_metrics]).mean()
+        avg_loss_pp = torch.stack([m["loss_per_position"] for m in all_step_metrics]).mean(dim=0)
+        avg_acc_pp = torch.stack([m["acc_per_position"] for m in all_step_metrics]).mean(dim=0)
 
         dist.all_reduce(avg_loss, op=dist.ReduceOp.AVG)
         dist.all_reduce(avg_acc, op=dist.ReduceOp.AVG)
+        dist.all_reduce(avg_loss_pp, op=dist.ReduceOp.AVG)
+        dist.all_reduce(avg_acc_pp, op=dist.ReduceOp.AVG)
+
+        # Skip index 0 (anchor slot, always zero); indices 1..B-1 are the
+        # predicted tokens at 1..B-1 steps past the anchor. Re-index to 0..B-2
+        # so the naming matches Eagle3 (acc_0 = first predicted token).
+        pred_loss_pp = avg_loss_pp[1:]
+        pred_acc_pp = avg_acc_pp[1:]
+
+        # Simulated accepted length: acc_0 + acc_0*acc_1 + ... + prod(acc_0..acc_{B-2})
+        # Models the expected number of consecutively accepted draft tokens.
+        cumulative = 1.0
+        simulated_acc_len = 0.0
+        for i in range(pred_acc_pp.shape[0]):
+            cumulative *= pred_acc_pp[i].item()
+            simulated_acc_len += cumulative
 
         metrics = {
             "train/avg_loss": avg_loss.item(),
             "train/avg_acc": avg_acc.item(),
+            "train/simulated_acc_len": simulated_acc_len,
             "train/grad_norm": grad_norm.item() if grad_norm is not None else 0.0,
             "train/global_step": self.global_step,
             "train/lr": self.optimizer.get_learning_rate(),
             "train/step": step,
         }
+
+        for i in range(pred_loss_pp.shape[0]):
+            metrics[f"train/ploss_{i}"] = pred_loss_pp[i].item()
+            metrics[f"train/acc_{i}"] = pred_acc_pp[i].item()
 
         # Sub-timing breakdown (forward vs backward)
         fwd_ms = sum(

--- a/torchspec/training/dflash_trainer.py
+++ b/torchspec/training/dflash_trainer.py
@@ -253,7 +253,7 @@ class DFlashTrainer(Trainer):
 
     def _forward(
         self, batch: dict
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         device = torch.device("cuda")
         input_ids = batch["input_ids"].to(device, non_blocking=True)
         hidden_states = batch["hidden_states"].to(device, non_blocking=True)
@@ -266,14 +266,14 @@ class DFlashTrainer(Trainer):
         hidden_states_list = self._split_hidden_states(hidden_states)
         del hidden_states
 
-        loss, accuracy, loss_per_position, acc_per_position = self.model(
+        loss, accuracy, loss_per_position, acc_per_position, count_per_position = self.model(
             input_ids=input_ids,
             hidden_states_list=hidden_states_list,
             loss_mask=loss_mask,
             lm_head_weight=self.target_lm_head_weight,
         )
 
-        return loss, accuracy, loss_per_position, acc_per_position
+        return loss, accuracy, loss_per_position, acc_per_position, count_per_position
 
     def _backward(self, loss: torch.Tensor, accumulation_steps: int = 1) -> torch.Tensor:
         scaled_loss = loss / accumulation_steps
@@ -287,11 +287,56 @@ class DFlashTrainer(Trainer):
     def eval_forward(self, batch: dict) -> dict:
         """Single forward pass without backward — returns per-position tensors."""
         with torch.no_grad():
-            _, _, loss_per_position, acc_per_position = self._forward(batch)
+            _, _, loss_per_position, acc_per_position, count_per_position = self._forward(batch)
         return {
             "loss_pp": loss_per_position.detach(),
             "acc_pp": acc_per_position.detach(),
+            "count_pp": count_per_position.detach(),
         }
+
+    def _reduce_position_metrics(
+        self,
+        all_step_metrics: list[dict],
+        *,
+        loss_key: str,
+        acc_key: str,
+        count_key: str,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        loss_sum_pp = torch.stack([m[loss_key] * m[count_key] for m in all_step_metrics]).sum(dim=0)
+        correct_sum_pp = torch.stack([m[acc_key] * m[count_key] for m in all_step_metrics]).sum(
+            dim=0
+        )
+        count_pp = torch.stack([m[count_key] for m in all_step_metrics]).sum(dim=0)
+
+        dist.all_reduce(loss_sum_pp, op=dist.ReduceOp.SUM)
+        dist.all_reduce(correct_sum_pp, op=dist.ReduceOp.SUM)
+        dist.all_reduce(count_pp, op=dist.ReduceOp.SUM)
+
+        safe_count_pp = count_pp.clamp(min=1.0)
+        avg_loss_pp = loss_sum_pp / safe_count_pp
+        avg_acc_pp = correct_sum_pp / safe_count_pp
+        return avg_loss_pp, avg_acc_pp, count_pp
+
+    def _compute_scalar_metrics(
+        self,
+        pred_loss_pp: torch.Tensor,
+        pred_acc_pp: torch.Tensor,
+        pred_count_pp: torch.Tensor,
+    ) -> Tuple[float, float]:
+        safe_total_count = pred_count_pp.sum().clamp(min=1.0)
+        avg_acc = ((pred_acc_pp * pred_count_pp).sum() / safe_total_count).item()
+
+        gamma = self.loss_decay_gamma
+        if gamma is not None and gamma > 0:
+            k = torch.arange(pred_loss_pp.shape[0], device=pred_loss_pp.device)
+            weights = torch.exp(-k.float() / gamma)
+        else:
+            weights = torch.ones_like(pred_loss_pp)
+
+        weighted_counts = pred_count_pp * weights
+        safe_weighted_count = weighted_counts.sum().clamp(min=1.0)
+        avg_loss = ((pred_loss_pp * weighted_counts).sum() / safe_weighted_count).item()
+        return avg_loss, avg_acc
 
     def eval_from_cache(self) -> dict:
         """Run forward-only eval over all CPU-cached eval samples.
@@ -323,15 +368,17 @@ class DFlashTrainer(Trainer):
         if not all_step_metrics:
             return {}
 
-        avg_loss_pp = torch.stack([m["loss_pp"] for m in all_step_metrics]).mean(dim=0)
-        avg_acc_pp = torch.stack([m["acc_pp"] for m in all_step_metrics]).mean(dim=0)
-
-        dist.all_reduce(avg_loss_pp, op=dist.ReduceOp.AVG)
-        dist.all_reduce(avg_acc_pp, op=dist.ReduceOp.AVG)
+        avg_loss_pp, avg_acc_pp, count_pp = self._reduce_position_metrics(
+            all_step_metrics,
+            loss_key="loss_pp",
+            acc_key="acc_pp",
+            count_key="count_pp",
+        )
 
         # Drop anchor slot (index 0) — see _aggregate_metrics for rationale.
         pred_loss_pp = avg_loss_pp[1:]
         pred_acc_pp = avg_acc_pp[1:]
+        pred_count_pp = count_pp[1:]
 
         cumulative = 1.0
         simulated_acc_len = 0.0
@@ -339,22 +386,13 @@ class DFlashTrainer(Trainer):
             cumulative *= pred_acc_pp[i].item()
             simulated_acc_len += cumulative
 
-        # Weighted avg loss using the same decay as the training objective,
-        # so eval/avg_loss is directly comparable to train/avg_loss.
-        gamma = self.loss_decay_gamma
-        if gamma is not None and gamma > 0:
-            k = torch.arange(pred_loss_pp.shape[0], device=pred_loss_pp.device)
-            # In forward, position-in-block k has weight exp(-(k-1)/gamma) for k>=1.
-            # After slicing away index 0, predicted index i corresponds to k=i+1,
-            # so weights become exp(-i/gamma).
-            weights = torch.exp(-k.float() / gamma)
-        else:
-            weights = torch.ones_like(pred_loss_pp)
-        weighted_avg_loss = (pred_loss_pp * weights).sum().item() / weights.sum().item()
+        weighted_avg_loss, avg_acc = self._compute_scalar_metrics(
+            pred_loss_pp, pred_acc_pp, pred_count_pp
+        )
 
         metrics: dict = {
             "eval/avg_loss": weighted_avg_loss,
-            "eval/avg_acc": pred_acc_pp.mean().item(),
+            "eval/avg_acc": avg_acc,
             "eval/simulated_acc_len": simulated_acc_len,
         }
         for i in range(pred_loss_pp.shape[0]):
@@ -363,7 +401,7 @@ class DFlashTrainer(Trainer):
 
         if dist.get_rank() == 0:
             logger.info(
-                f"eval: loss={weighted_avg_loss:.4f}, acc={pred_acc_pp.mean().item():.4f}, "
+                f"eval: loss={weighted_avg_loss:.4f}, acc={avg_acc:.4f}, "
                 f"sim_acc_len={simulated_acc_len:.2f}"
             )
 
@@ -387,7 +425,9 @@ class DFlashTrainer(Trainer):
         evt_bwd_e = torch.cuda.Event(enable_timing=True)
 
         evt_fwd_s.record()
-        loss, accuracy, loss_per_position, acc_per_position = self._forward(batch)
+        loss, accuracy, loss_per_position, acc_per_position, count_per_position = self._forward(
+            batch
+        )
         evt_fwd_e.record()
 
         evt_bwd_s.record()
@@ -399,6 +439,7 @@ class DFlashTrainer(Trainer):
             "accuracy": accuracy.detach(),
             "loss_per_position": loss_per_position.detach(),
             "acc_per_position": acc_per_position.detach(),
+            "count_per_position": count_per_position.detach(),
             "total_loss": total_loss.detach(),
             "_fwd_events": (evt_fwd_s, evt_fwd_e),
             "_bwd_events": (evt_bwd_s, evt_bwd_e),
@@ -410,21 +451,19 @@ class DFlashTrainer(Trainer):
         if not all_step_metrics:
             return {}
 
-        avg_loss = torch.stack([m["loss"] for m in all_step_metrics]).mean()
-        avg_acc = torch.stack([m["accuracy"] for m in all_step_metrics]).mean()
-        avg_loss_pp = torch.stack([m["loss_per_position"] for m in all_step_metrics]).mean(dim=0)
-        avg_acc_pp = torch.stack([m["acc_per_position"] for m in all_step_metrics]).mean(dim=0)
-
-        dist.all_reduce(avg_loss, op=dist.ReduceOp.AVG)
-        dist.all_reduce(avg_acc, op=dist.ReduceOp.AVG)
-        dist.all_reduce(avg_loss_pp, op=dist.ReduceOp.AVG)
-        dist.all_reduce(avg_acc_pp, op=dist.ReduceOp.AVG)
+        avg_loss_pp, avg_acc_pp, count_pp = self._reduce_position_metrics(
+            all_step_metrics,
+            loss_key="loss_per_position",
+            acc_key="acc_per_position",
+            count_key="count_per_position",
+        )
 
         # Skip index 0 (anchor slot, always zero); indices 1..B-1 are the
         # predicted tokens at 1..B-1 steps past the anchor. Re-index to 0..B-2
         # so the naming matches Eagle3 (acc_0 = first predicted token).
         pred_loss_pp = avg_loss_pp[1:]
         pred_acc_pp = avg_acc_pp[1:]
+        pred_count_pp = count_pp[1:]
 
         # Simulated accepted length: acc_0 + acc_0*acc_1 + ... + prod(acc_0..acc_{B-2})
         # Models the expected number of consecutively accepted draft tokens.
@@ -434,9 +473,11 @@ class DFlashTrainer(Trainer):
             cumulative *= pred_acc_pp[i].item()
             simulated_acc_len += cumulative
 
+        avg_loss, avg_acc = self._compute_scalar_metrics(pred_loss_pp, pred_acc_pp, pred_count_pp)
+
         metrics = {
-            "train/avg_loss": avg_loss.item(),
-            "train/avg_acc": avg_acc.item(),
+            "train/avg_loss": avg_loss,
+            "train/avg_acc": avg_acc,
             "train/simulated_acc_len": simulated_acc_len,
             "train/grad_norm": grad_norm.item() if grad_norm is not None else 0.0,
             "train/global_step": self.global_step,


### PR DESCRIPTION
## Summary

- **Per-position train metrics** — `DFlashModel.forward` now returns `loss_per_position` and `acc_per_position` (shape `[block_size]`). `DFlashTrainer._aggregate_metrics` slices off the anchor slot and emits `train/ploss_i`, `train/acc_i` (for `i = 0..B-2`, so `acc_0` is the first predicted token — matches Eagle3 semantics) plus `train/simulated_acc_len` (cumulative product of per-position accs).
- **Real eval path** — replaces the stubbed `eval_from_cache` → `{}` with `eval_forward` / `eval_from_cache` / `_aggregate_eval_metrics` that mirror `Eagle3Trainer`. Eval loss is decay-weighted with `self.loss_decay_gamma` so `eval/avg_loss` is directly comparable to `train/avg_loss`; also emits `eval/avg_acc`, `eval/simulated_acc_len`, and per-`i` `eval/ploss_i`, `eval/acc_i`. The stale "eval hangs in colocate/SGLang mode" comment is gone — the controller already calls `eval_from_cache` every `eval_interval` and all current DFlash training configs are non-colocated.
- **Hard-pin on DFlash configs** — `configs/dflash_qwen3_8b_repro.yaml` and `configs/sglang_qwen3_8b_dflash.yaml` set `mooncake.enable_hard_pin: true`. With force-delete (landed in #73), the TTL path is no longer our cleanup path; hard-pin makes \`remove(force=True)\` the only way an object leaves the store. Requires \`mooncake-transfer-engine >= 0.3.10.post1\`, already pinned in \`pyproject.toml\`.

## Why

The linked wandb decagon runs log per-TTT-position metrics and the eval suite, but DFlash runs were showing only scalar \`train/avg_loss\` / \`train/avg_acc\` with no eval panel — making it impossible to diagnose *which* predicted position is failing when a run diverges (historically around steps 100–500 on m27). This brings DFlash to Eagle3 parity in wandb.

## Test plan

- [x] \`pytest tests/test_dflash.py\` → 62 passed. Updated 8 call sites to unpack the new 4-tuple return from \`DFlashModel.forward\`; added a shape assertion on the new per-position tensors.
- [x] \`MooncakeConfig.from_flat_args\` loads both DFlash configs with \`enable_hard_pin=True\`.
- [ ] Dry-run one training step + one eval step on a tiny DFlash config to confirm \`train/acc_i\`, \`train/ploss_i\`, \`train/simulated_acc_len\`, and the \`eval/*\` keys appear in wandb (in-progress).