### PR TITLE
Avoid fractional GPU requests inside placement groups

### DIFF
--- a/torchspec/inference/factory.py
+++ b/torchspec/inference/factory.py
@@ -207,9 +207,11 @@ def _prepare_sgl_engines(
             placement_group_bundle_index=reordered_bundle_indices[bundle_offset],
         )
 
+        # The placement group already reserves the target GPU. Keep the actor's
+        # Ray resource request CPU-only and pass base_gpu_id for CUDA setup to
+        # avoid noisy fractional GPU_group_* demands in the autoscaler.
         engine = SglRayActor.options(
             num_cpus=0.2,
-            num_gpus=0.2,
             scheduling_strategy=scheduling_strategy,
             runtime_env={"env_vars": env_vars},
         ).remote(
@@ -349,9 +351,11 @@ def _prepare_vllm_engines(
             placement_group_bundle_index=reordered_bundle_indices[bundle_offset],
         )
 
+        # The placement group already reserves the target GPU. Keep the actor's
+        # Ray resource request CPU-only and pass base_gpu_id for CUDA setup to
+        # avoid noisy fractional GPU_group_* demands in the autoscaler.
         engine = VllmRayActor.options(
             num_cpus=0.2,
-            num_gpus=0.2,
             scheduling_strategy=scheduling_strategy,
             runtime_env={"env_vars": env_vars},
         ).remote(
@@ -460,8 +464,10 @@ def _create_and_init_actors(
     init_handles = []
 
     for i in range(num_engines):
-        num_gpus = 0.2
-        num_cpus = num_gpus
+        # The placement group already reserves the target GPU. Keep the actor's
+        # Ray resource request CPU-only and pass base_gpu_id for CUDA setup to
+        # avoid noisy fractional GPU_group_* demands in the autoscaler.
+        num_cpus = 0.2
 
         base_gpu_id = int(reordered_gpu_ids[i * num_gpus_per_engine])
 
@@ -484,7 +490,6 @@ def _create_and_init_actors(
 
         engine = ray_actor_cls.options(
             num_cpus=num_cpus,
-            num_gpus=num_gpus,
             scheduling_strategy=scheduling_strategy,
             runtime_env={"env_vars": env_vars},
         ).remote(**constructor_kwargs)

--- a/torchspec/ray/train_group.py
+++ b/torchspec/ray/train_group.py
@@ -40,8 +40,8 @@ class RayTrainGroup:
         num_gpus_per_node (int): Number of gpus for this training group.
         pg (PlacementGroup, optional): Placement group to schedule training workers on.
             If none, create new placement group automatically. Defaults to None.
-        num_gpus_per_actor (float, optional): Number of gpus allocated for each training worker.
-            If < 1.0, multiple models can share same gpu. Defaults to 1.
+        num_gpus_per_actor (float, optional): Legacy CPU reservation size for each
+            training worker when scheduled inside a GPU placement-group bundle.
         resources (Dict[str, float], optional): Custom resources to allocate for each training worker.
             See https://docs.ray.io/en/latest/ray-core/scheduling/resources.html
         num_resources_per_node (int, optional): Number of custom resources to allocate for each node.
@@ -73,7 +73,7 @@ class RayTrainGroup:
 
         # Use placement group to lock resources for models of same type
         assert pg is not None
-        pg, reordered_bundle_indices, _reordered_gpu_ids = pg
+        pg, reordered_bundle_indices, reordered_gpu_ids = pg
 
         train_env_vars = self.args.train_env_vars
         if isinstance(train_env_vars, str):
@@ -98,9 +98,11 @@ class RayTrainGroup:
             os.environ.get("TORCHINDUCTOR_FX_GRAPH_CACHE", "1"),
         )
 
-        TrainRayActor = ray.remote(num_gpus=1, runtime_env={"env_vars": env_vars})(
-            self._training_class
-        )
+        # The placement group has already reserved the GPU bundle. Requesting an
+        # additional fractional GPU from the actor creates transient GPU_group_*
+        # demands that Ray's autoscaler can misreport as infeasible. Keep actor
+        # resource accounting CPU-only and pass the intended GPU id explicitly.
+        TrainRayActor = ray.remote(runtime_env={"env_vars": env_vars})(self._training_class)
 
         # Create worker actors
         self._actor_handlers = []
@@ -108,12 +110,17 @@ class RayTrainGroup:
         for rank in range(world_size):
             actor = TrainRayActor.options(
                 num_cpus=num_gpus_per_actor,
-                num_gpus=num_gpus_per_actor,
                 scheduling_strategy=PlacementGroupSchedulingStrategy(
                     placement_group=pg,
                     placement_group_bundle_index=reordered_bundle_indices[rank],
                 ),
-            ).remote(world_size, rank, master_addr, master_port)
+            ).remote(
+                world_size,
+                rank,
+                master_addr,
+                master_port,
+                int(reordered_gpu_ids[rank]),
+            )
             if rank == 0:
                 master_addr, master_port = ray.get(actor.get_master_addr_and_port.remote())
             self._actor_handlers.append(actor)

--- a/torchspec/training/trainer_actor.py
+++ b/torchspec/training/trainer_actor.py
@@ -33,7 +33,14 @@ from torchspec.utils.logging import setup_file_logging
 
 
 class TrainerActor(RayActor):
-    def __init__(self, world_size: int, rank: int, master_addr: str, master_port: int):
+    def __init__(
+        self,
+        world_size: int,
+        rank: int,
+        master_addr: str,
+        master_port: int,
+        base_gpu_id: int | None = None,
+    ):
         self._world_size = world_size
         self._rank = rank
 
@@ -44,7 +51,7 @@ class TrainerActor(RayActor):
         os.environ["WORLD_SIZE"] = str(self._world_size)
         os.environ["RANK"] = str(self._rank)
 
-        self.setup_gpu()
+        self.setup_gpu(base_gpu_id)
         setup_file_logging("training", self._rank)
 
     def init(self, args: Namespace, role: str, mooncake_config=None, with_ref: bool = False) -> int:


### PR DESCRIPTION
## Summary

This is a small sketch of the placement-group cleanup discussed while debugging Ray's repeated `infeasible resource requests` warnings.

The GPU capacity is already reserved by the TorchSpec placement group bundles. The training/inference actors are then scheduled onto specific PG bundle indices and receive the selected physical GPU id explicitly. Requesting additional fractional GPU resources on those actors creates transient `GPU_group_*`/`CPU_group_*` demands that Ray's autoscaler can report as infeasible even though the workload eventually schedules and succeeds.

This PR changes those actors to keep Ray actor resource accounting CPU-only inside the already GPU-reserved bundles:

- remove fractional `num_gpus=0.2` from inference engine actors
- remove fractional `num_gpus_per_actor` GPU requests from training actors
- pass the selected PG GPU id into `TrainerActor` explicitly, matching the inference actor pattern

## Validation

- `python3 -m compileall -q torchspec/ray/train_group.py torchspec/training/trainer_actor.py torchspec/inference/factory.py`
- `uvx ruff check torchspec/ray/train_group.py torchspec/training/trainer_actor.py torchspec/inference/factory.py`
