### PR TITLE
feat: analytical Eagle3 BlockMask builder (O(num_blocks) memory)

### DIFF
--- a/tests/test_build_eagle3_block_mask.py
+++ b/tests/test_build_eagle3_block_mask.py
@@ -1,279 +1,184 @@
-"""Tests for build_eagle3_block_mask -- the analytical BlockMask builder."""
+"""Tests for build_eagle3_block_mask -- the analytical Eagle3 BlockMask builder."""
+
 import unittest
+
 import torch
+import torch._dynamo as dynamo
 from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 
 from torchspec.models.ops.flex_attention import (
+    _build_eagle3_block_mask_tensors,
     build_eagle3_block_mask,
     eagle3_block_mask,
     generate_eagle3_mask,
 )
 
+DEVICE = "cuda"
+BLOCK_SIZE = 128
 
-def _mask_to_dense_bool(Q_LEN, KV_LEN, bm, BLOCK_SIZE=128):
-    """Convert a BlockMask to a full (Q_LEN, KV_LEN) bool tensor via mask_mod."""
-    qi = torch.arange(Q_LEN, device="cuda").unsqueeze(1)
-    ki = torch.arange(KV_LEN, device="cuda").unsqueeze(0)
-    b = torch.zeros_like(qi)
+
+def dense_from_mod(Q_LEN, KV_LEN, mask_mod, batch_idx=0):
+    """Materialise a (Q_LEN, KV_LEN) bool grid from a mask_mod or BlockMask."""
+    qi = torch.arange(Q_LEN, device=DEVICE).unsqueeze(1)
+    ki = torch.arange(KV_LEN, device=DEVICE).unsqueeze(0)
+    b = torch.full_like(qi, batch_idx)
     h = torch.zeros_like(qi)
-    return bm.mask_mod(b, h, qi, ki).bool()
+    fn = mask_mod.mask_mod if hasattr(mask_mod, "mask_mod") else mask_mod
+    return fn(b, h, qi, ki).bool()
+
+
+def reference_block_mask(Q_LEN, KV_LEN, B=1, H=1):
+    """create_block_mask using the production simplified mask_mod."""
+    return create_block_mask(
+        generate_eagle3_mask(Q_LEN, KV_LEN),
+        B=B,
+        H=H,
+        Q_LEN=Q_LEN,
+        KV_LEN=KV_LEN,
+        device=DEVICE,
+    )
+
+
+# Sizes covering single round, short-multi-round, and aligned-multi-round cases.
+SHAPES = [(256, 256), (256, 768), (256, 1280), (1024, 4096)]
 
 
 class TestBuildEagle3BlockMask(unittest.TestCase):
+    """Analytical builder must produce a mask equivalent to create_block_mask."""
 
-    def _reference_block_mask(self, Q_LEN, KV_LEN, B=1, H=1, device="cuda"):
-        seq_lengths = torch.tensor([Q_LEN] * B, device=device, dtype=torch.int32)
-        mask_mod = generate_eagle3_mask(seq_lengths, Q_LEN, KV_LEN, lck=0)
-        return create_block_mask(mask_mod, B=B, H=H, Q_LEN=Q_LEN, KV_LEN=KV_LEN, device=device)
+    def test_dense_mask_matches_reference(self):
+        for Q, KV in SHAPES:
+            with self.subTest(Q=Q, KV=KV):
+                ref = dense_from_mod(Q, KV, reference_block_mask(Q, KV))
+                ours = dense_from_mod(Q, KV, build_eagle3_block_mask(Q, KV, device=DEVICE))
+                self.assertTrue(torch.equal(ref, ours))
 
-    def test_mask_pattern_matches_reference_small(self):
-        """Element-level mask pattern must be identical for small sizes."""
-        for n_rounds in [1, 2, 3, 5]:
-            Q_LEN = 256
-            KV_LEN = Q_LEN * n_rounds
-            with self.subTest(rounds=n_rounds):
-                ref = self._reference_block_mask(Q_LEN, KV_LEN)
-                ours = build_eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
-                ref_dense = _mask_to_dense_bool(Q_LEN, KV_LEN, ref)
-                our_dense = _mask_to_dense_bool(Q_LEN, KV_LEN, ours)
-                self.assertTrue(torch.equal(ref_dense, our_dense),
-                    f"Mask pattern mismatch at rounds={n_rounds}")
-
-    def test_mask_pattern_matches_reference_medium(self):
-        """Test at 1024 tokens with multiple rounds."""
-        for n_rounds in [1, 2, 4]:
-            Q_LEN = 1024
-            KV_LEN = Q_LEN * n_rounds
-            with self.subTest(rounds=n_rounds):
-                ref = self._reference_block_mask(Q_LEN, KV_LEN)
-                ours = build_eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
-                ref_dense = _mask_to_dense_bool(Q_LEN, KV_LEN, ref)
-                our_dense = _mask_to_dense_bool(Q_LEN, KV_LEN, ours)
-                self.assertTrue(torch.equal(ref_dense, our_dense))
-
-    def test_batch_size_broadcast(self):
-        """H=1 mask should work with multi-head attention via broadcast."""
-        Q_LEN, KV_LEN = 256, 768
-        bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=2, H=1, device="cuda")
-        self.assertEqual(bm.kv_num_blocks.shape[0], 2)
-        self.assertEqual(bm.kv_num_blocks.shape[1], 1)
-
-    def test_flex_attention_output_matches(self):
-        """flex_attention output must match between analytical and reference mask."""
+    def test_forward_matches_reference(self):
         torch.manual_seed(42)
         B, H, D = 1, 4, 64
-        Q_LEN = 512
-        for n_rounds in [1, 2, 3]:
-            KV_LEN = Q_LEN * n_rounds
-            with self.subTest(rounds=n_rounds):
-                q = torch.randn(B, H, Q_LEN, D, device="cuda", dtype=torch.bfloat16)
-                k = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.bfloat16)
-                v = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.bfloat16)
-
-                ref_bm = self._reference_block_mask(Q_LEN, KV_LEN)
-                our_bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=B, H=1, device="cuda")
-
-                out_ref = flex_attention(q, k, v, block_mask=ref_bm, enable_gqa=False)
-                out_ours = flex_attention(q, k, v, block_mask=our_bm, enable_gqa=False)
-
-                self.assertEqual(out_ref.shape, out_ours.shape)
-                self.assertFalse(out_ours.isnan().any())
-                max_diff = (out_ref - out_ours).abs().max().item()
-                self.assertAlmostEqual(max_diff, 0.0, places=5,
-                    msg=f"Output diff={max_diff} at rounds={n_rounds}")
-
-    def test_flex_attention_gqa(self):
-        """Test with GQA (fewer KV heads than Q heads)."""
-        torch.manual_seed(42)
-        B, Q_HEADS, KV_HEADS, D = 1, 8, 2, 64
-        Q_LEN, KV_LEN = 256, 768
-
-        q = torch.randn(B, Q_HEADS, Q_LEN, D, device="cuda", dtype=torch.bfloat16)
-        k = torch.randn(B, KV_HEADS, KV_LEN, D, device="cuda", dtype=torch.bfloat16)
-        v = torch.randn(B, KV_HEADS, KV_LEN, D, device="cuda", dtype=torch.bfloat16)
-
-        bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=B, H=1, device="cuda")
-        out = flex_attention(q, k, v, block_mask=bm, enable_gqa=True)
-
-        self.assertEqual(out.shape, (B, Q_HEADS, Q_LEN, D))
-        self.assertFalse(out.isnan().any())
-
-    def test_backward_pass(self):
-        """Gradients must flow through flex_attention with analytical mask."""
-        torch.manual_seed(42)
-        B, H, D = 1, 4, 64
-        Q_LEN, KV_LEN = 256, 768
-
-        q = torch.randn(B, H, Q_LEN, D, device="cuda", dtype=torch.float32, requires_grad=True)
-        k = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.float32, requires_grad=True)
-        v = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.float32, requires_grad=True)
-
-        bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=B, H=1, device="cuda")
-        out = flex_attention(q, k, v, block_mask=bm, enable_gqa=False)
-        out.sum().backward()
-
-        for name, t in [("q", q), ("k", k), ("v", v)]:
-            self.assertIsNotNone(t.grad, f"{name}.grad is None")
-            self.assertFalse(t.grad.isnan().any(), f"{name}.grad has NaN")
+        for Q, KV in SHAPES:
+            with self.subTest(Q=Q, KV=KV):
+                q = torch.randn(B, H, Q, D, device=DEVICE, dtype=torch.bfloat16)
+                k = torch.randn(B, H, KV, D, device=DEVICE, dtype=torch.bfloat16)
+                v = torch.randn(B, H, KV, D, device=DEVICE, dtype=torch.bfloat16)
+                ref = flex_attention(q, k, v, block_mask=reference_block_mask(Q, KV))
+                ours = flex_attention(q, k, v, block_mask=build_eagle3_block_mask(Q, KV, B=B))
+                self.assertEqual(ref.shape, ours.shape)
+                self.assertFalse(ours.isnan().any())
+                self.assertLess((ref - ours).abs().max().item(), 1e-5)
 
     def test_backward_gradients_match_reference(self):
-        """Gradients must match between analytical and reference masks."""
         torch.manual_seed(42)
-        B, H, D = 1, 4, 64
-        Q_LEN, KV_LEN = 256, 768
+        B, H, D, Q, KV = 1, 4, 64, 256, 768
 
-        q1 = torch.randn(B, H, Q_LEN, D, device="cuda", dtype=torch.float32, requires_grad=True)
-        k1 = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.float32, requires_grad=True)
-        v1 = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.float32, requires_grad=True)
-        q2, k2, v2 = [t.clone().detach().requires_grad_(True) for t in (q1, k1, v1)]
+        def grads(mask):
+            q = torch.randn(B, H, Q, D, device=DEVICE, dtype=torch.float32, requires_grad=True)
+            k = torch.randn(B, H, KV, D, device=DEVICE, dtype=torch.float32, requires_grad=True)
+            v = torch.randn(B, H, KV, D, device=DEVICE, dtype=torch.float32, requires_grad=True)
+            flex_attention(q, k, v, block_mask=mask).sum().backward()
+            return q.grad, k.grad, v.grad
 
-        ref_bm = self._reference_block_mask(Q_LEN, KV_LEN)
-        our_bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=B, H=1, device="cuda")
+        torch.manual_seed(42)
+        gq_r, gk_r, gv_r = grads(reference_block_mask(Q, KV))
+        torch.manual_seed(42)
+        gq_o, gk_o, gv_o = grads(build_eagle3_block_mask(Q, KV, B=B))
+        for name, gr, go in [("q", gq_r, gq_o), ("k", gk_r, gk_o), ("v", gv_r, gv_o)]:
+            self.assertLess((gr - go).abs().max().item(), 1e-4, f"grad mismatch on {name}")
 
-        flex_attention(q1, k1, v1, block_mask=ref_bm, enable_gqa=False).sum().backward()
-        flex_attention(q2, k2, v2, block_mask=our_bm, enable_gqa=False).sum().backward()
-
-        for name, g1, g2 in [("q", q1.grad, q2.grad), ("k", k1.grad, k2.grad), ("v", v1.grad, v2.grad)]:
-            max_diff = (g1 - g2).abs().max().item()
-            self.assertAlmostEqual(max_diff, 0.0, places=4,
-                msg=f"Gradient mismatch for {name}: max_diff={max_diff}")
-
-    def test_causal_only_single_round(self):
-        """With KV_LEN == Q_LEN (1 round), mask should be purely causal."""
-        Q_LEN = 256
-        bm = build_eagle3_block_mask(Q_LEN, Q_LEN, B=1, H=1, device="cuda")
-        dense = _mask_to_dense_bool(Q_LEN, Q_LEN, bm)
-
-        # Lower triangular
-        expected = torch.tril(torch.ones(Q_LEN, Q_LEN, device="cuda", dtype=torch.bool))
-        self.assertTrue(torch.equal(dense, expected), "Single round should be purely causal")
-
-    def test_suffix_diagonal_structure(self):
-        """Suffix rounds should have exactly one active element per row (diagonal)."""
-        Q_LEN = 256
-        KV_LEN = 256 * 3  # 3 rounds: 1 causal + 2 suffix
-        bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
-        dense = _mask_to_dense_bool(Q_LEN, KV_LEN, bm)
-
-        # Check suffix region (kv_idx >= Q_LEN)
-        suffix_mask = dense[:, Q_LEN:]  # (Q_LEN, 2*Q_LEN)
-        for qi in range(Q_LEN):
-            active_kv = suffix_mask[qi].nonzero().squeeze(-1)
-            # Should have exactly 2 active positions (one per suffix round)
-            self.assertEqual(active_kv.numel(), 2,
-                f"Row {qi}: expected 2 suffix positions, got {active_kv.numel()}")
+    def test_gqa_broadcast(self):
+        """H=1 mask broadcasts over multi-Q-head GQA without NaN."""
+        torch.manual_seed(0)
+        B, Qh, KVh, D, Q, KV = 1, 8, 2, 64, 256, 768
+        q = torch.randn(B, Qh, Q, D, device=DEVICE, dtype=torch.bfloat16)
+        k = torch.randn(B, KVh, KV, D, device=DEVICE, dtype=torch.bfloat16)
+        v = torch.randn(B, KVh, KV, D, device=DEVICE, dtype=torch.bfloat16)
+        bm = build_eagle3_block_mask(Q, KV, B=B, device=DEVICE)
+        out = flex_attention(q, k, v, block_mask=bm, enable_gqa=True)
+        self.assertEqual(out.shape, (B, Qh, Q, D))
+        self.assertFalse(out.isnan().any())
 
     def test_memory_is_negligible(self):
-        """Analytical builder should use negligible memory."""
-        Q_LEN, KV_LEN = 4096, 4096 * 5
+        """Original create_block_mask costs ~112 GB at Q=49K; this must stay in MB."""
+        Q, KV = 4096, 4096 * 5
         torch.cuda.reset_peak_memory_stats()
         before = torch.cuda.memory_allocated()
-        bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
-        after = torch.cuda.max_memory_allocated()
-        mem_mb = (after - before) / 1024**2
-        self.assertLess(mem_mb, 10.0,
-            f"Block mask used {mem_mb:.1f} MB -- should be negligible")
+        build_eagle3_block_mask(Q, KV, device=DEVICE)
+        mem_mb = (torch.cuda.max_memory_allocated() - before) / 1024**2
+        self.assertLess(mem_mb, 10.0, f"used {mem_mb:.1f} MB")
 
-    def test_assertion_on_non_divisible(self):
-        """Should raise if Q_LEN or KV_LEN not divisible by BLOCK_SIZE."""
+    def test_assertions_on_invalid_shapes(self):
+        # not divisible by BLOCK_SIZE
         with self.assertRaises(AssertionError):
-            build_eagle3_block_mask(100, 300, B=1, H=1, device="cuda")
-
-    def test_assertion_on_non_round_aligned_kv(self):
-        """Should raise if KV_LEN is not an integer multiple of Q_LEN."""
-        # 256-aligned to BLOCK_SIZE but KV_LEN % Q_LEN != 0.
+            build_eagle3_block_mask(100, 300, device=DEVICE)
+        # KV not a Q-multiple
         with self.assertRaises(AssertionError):
-            build_eagle3_block_mask(256, 384, B=1, H=1, device="cuda")
+            build_eagle3_block_mask(256, 384, device=DEVICE)
 
 
 class TestEagle3BlockMaskDispatcher(unittest.TestCase):
-    """Tests for the eagle3_block_mask dispatcher (analytical + fallback)."""
+    """Dispatcher picks analytical when shapes align, otherwise falls back."""
 
-    def _ref_dense(self, Q_LEN, KV_LEN, bm):
-        qi = torch.arange(Q_LEN, device="cuda").unsqueeze(1)
-        ki = torch.arange(KV_LEN, device="cuda").unsqueeze(0)
-        b = torch.zeros_like(qi)
-        h = torch.zeros_like(qi)
-        return bm.mask_mod(b, h, qi, ki).bool()
+    def test_analytical_path_when_aligned(self):
+        for Q, KV in [(256, 256), (256, 768)]:
+            with self.subTest(Q=Q, KV=KV):
+                disp = eagle3_block_mask(Q, KV, B=1, H=1, device=DEVICE)
+                ana = build_eagle3_block_mask(Q, KV, device=DEVICE)
+                self.assertTrue(torch.equal(disp.kv_indices, ana.kv_indices))
+                self.assertTrue(torch.equal(disp.q_indices, ana.q_indices))
 
-    def test_dispatcher_picks_analytical_path(self):
-        """When Q_LEN aligned & KV_LEN % Q_LEN == 0, output must equal analytical builder."""
-        Q_LEN, KV_LEN = 256, 256 * 3
-        dispatched = eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
-        analytical = build_eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
-        # Same kv_indices/q_indices structure indicates analytical path was taken.
-        self.assertTrue(torch.equal(dispatched.kv_num_blocks, analytical.kv_num_blocks))
-        self.assertTrue(torch.equal(dispatched.kv_indices, analytical.kv_indices))
-        self.assertTrue(torch.equal(dispatched.q_num_blocks, analytical.q_num_blocks))
-        self.assertTrue(torch.equal(dispatched.q_indices, analytical.q_indices))
+    def test_fallback_path_matches_reference_mask_mod(self):
+        """Fallback shapes (Q<BLOCK_SIZE, or KV%Q!=0) must produce the canonical mask."""
+        for Q, KV in [(64, 64), (256, 384)]:
+            with self.subTest(Q=Q, KV=KV):
+                bm = eagle3_block_mask(Q, KV, B=1, H=1, device=DEVICE)
+                expected = dense_from_mod(Q, KV, generate_eagle3_mask(Q, KV))
+                self.assertTrue(torch.equal(dense_from_mod(Q, KV, bm), expected))
 
-    def test_dispatcher_first_round_uses_analytical(self):
-        """First round (KV_LEN == Q_LEN) is now handled by the analytical builder."""
-        Q_LEN = 256
-        dispatched = eagle3_block_mask(Q_LEN, Q_LEN, B=1, H=1, device="cuda")
-        analytical = build_eagle3_block_mask(Q_LEN, Q_LEN, B=1, H=1, device="cuda")
-        self.assertTrue(torch.equal(dispatched.kv_indices, analytical.kv_indices))
-
-    def test_dispatcher_falls_back_when_q_too_small(self):
-        """When Q_LEN < BLOCK_SIZE, must fall back to create_block_mask without raising."""
-        Q_LEN, KV_LEN = 64, 64
-        bm = eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
-        # Should produce a causal-only mask and not raise.
-        dense = self._ref_dense(Q_LEN, KV_LEN, bm)
-        expected = torch.tril(torch.ones(Q_LEN, KV_LEN, device="cuda", dtype=torch.bool))
-        self.assertTrue(torch.equal(dense, expected))
-
-    def test_dispatcher_falls_back_when_kv_not_round_multiple(self):
-        """When KV_LEN % Q_LEN != 0, must fall back rather than raising the assert."""
-        # 256 and 384 are both multiples of 128 but 384 % 256 != 0, so analytical
-        # path's diagonal layout would be wrong: dispatcher must take the fallback.
-        Q_LEN, KV_LEN = 256, 384
-        bm = eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
-        # Mask correctness is verified element-wise against the canonical mask_mod.
-        seq_lengths = torch.tensor([Q_LEN], device="cuda", dtype=torch.int32)
-        ref_mod = generate_eagle3_mask(seq_lengths, Q_LEN, KV_LEN, lck=0)
-        qi = torch.arange(Q_LEN, device="cuda").unsqueeze(1)
-        ki = torch.arange(KV_LEN, device="cuda").unsqueeze(0)
-        b = torch.zeros_like(qi)
-        h = torch.zeros_like(qi)
-        expected = ref_mod(b, h, qi, ki).bool()
-        actual = bm.mask_mod(b, h, qi, ki).bool()
-        self.assertTrue(torch.equal(actual, expected))
-
-    def test_dispatcher_flex_attention_matches_reference(self):
-        """flex_attention output via dispatcher must match the create_block_mask reference."""
-        torch.manual_seed(42)
+    def test_dispatcher_forward_matches_reference(self):
+        torch.manual_seed(0)
         B, H, D = 1, 4, 64
-        for Q_LEN, KV_LEN in [(256, 256), (256, 256 * 3), (512, 512 * 4)]:
-            with self.subTest(Q_LEN=Q_LEN, KV_LEN=KV_LEN):
-                q = torch.randn(B, H, Q_LEN, D, device="cuda", dtype=torch.bfloat16)
-                k = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.bfloat16)
-                v = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.bfloat16)
-
-                seq_lengths = torch.tensor([Q_LEN] * B, device="cuda", dtype=torch.int32)
-                ref_bm = create_block_mask(
-                    generate_eagle3_mask(seq_lengths, Q_LEN, KV_LEN, lck=0),
-                    B=B, H=1, Q_LEN=Q_LEN, KV_LEN=KV_LEN, device="cuda",
+        for Q, KV in [(256, 256), (256, 768)]:
+            with self.subTest(Q=Q, KV=KV):
+                q = torch.randn(B, H, Q, D, device=DEVICE, dtype=torch.bfloat16)
+                k = torch.randn(B, H, KV, D, device=DEVICE, dtype=torch.bfloat16)
+                v = torch.randn(B, H, KV, D, device=DEVICE, dtype=torch.bfloat16)
+                ref = flex_attention(q, k, v, block_mask=reference_block_mask(Q, KV, B=B))
+                disp = flex_attention(
+                    q, k, v, block_mask=eagle3_block_mask(Q, KV, B=B, H=1, device=DEVICE)
                 )
-                dispatched_bm = eagle3_block_mask(
-                    Q_LEN, KV_LEN, B=B, H=1, device="cuda",
-                )
+                self.assertLess((ref - disp).abs().max().item(), 1e-5)
 
-                out_ref = flex_attention(q, k, v, block_mask=ref_bm, enable_gqa=False)
-                out_disp = flex_attention(q, k, v, block_mask=dispatched_bm, enable_gqa=False)
-                self.assertEqual(out_ref.shape, out_disp.shape)
-                max_diff = (out_ref - out_disp).abs().max().item()
-                self.assertAlmostEqual(max_diff, 0.0, places=5,
-                    msg=f"Output diff={max_diff} at Q={Q_LEN}, KV={KV_LEN}")
 
-    def test_dispatcher_seq_lengths_optional(self):
-        """seq_lengths is optional; analytical path ignores it, fallback synthesises a default."""
-        # Analytical path: no seq_lengths required.
-        bm1 = eagle3_block_mask(256, 768, B=1, H=1, device="cuda")
-        self.assertEqual(bm1.kv_indices.shape[0], 1)
-        # Fallback path: omitted seq_lengths must not raise.
-        bm2 = eagle3_block_mask(64, 64, B=1, H=1, device="cuda")
-        self.assertIsNotNone(bm2)
+class TestCompiledTensorBuilder(unittest.TestCase):
+    """build_eagle3_block_mask routes through torch.compile -- verify behaviour."""
+
+    def test_compiled_output_matches_eager(self):
+        for Q, KV in [(256, 256), (256, 768), (1024, 4096)]:
+            with self.subTest(Q=Q, KV=KV):
+                eager = _build_eagle3_block_mask_tensors(Q, KV, 1, 1, BLOCK_SIZE, DEVICE)
+                bm = build_eagle3_block_mask(Q, KV, device=DEVICE)
+                self.assertTrue(torch.equal(bm.kv_num_blocks, eager[0]))
+                self.assertTrue(torch.equal(bm.kv_indices, eager[1]))
+                self.assertTrue(torch.equal(bm.q_num_blocks, eager[2]))
+                self.assertTrue(torch.equal(bm.q_indices, eager[3]))
+
+    def test_dynamic_true_does_not_recompile_across_growing_kv(self):
+        """KV_LEN grows by Q_LEN every TTT step; dynamic=True must keep one graph."""
+        Q = 512
+        # Warm up to lock the compiled artifact.
+        build_eagle3_block_mask(Q, Q, device=DEVICE)
+        dynamo.reset()
+        build_eagle3_block_mask(Q, Q, device=DEVICE)
+        before = dynamo.utils.counters["stats"].get("unique_graphs", 0)
+        for n_rounds in [2, 3, 4, 5]:
+            build_eagle3_block_mask(Q, Q * n_rounds, device=DEVICE)
+        after = dynamo.utils.counters["stats"].get("unique_graphs", 0)
+        # First call after dynamo.reset() compiles once (+1); growing KV must not add more.
+        self.assertLessEqual(
+            after - before,
+            1,
+            f"dynamic=True triggered {after - before} extra graphs across growing KV",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_build_eagle3_block_mask.py
+++ b/tests/test_build_eagle3_block_mask.py
@@ -1,0 +1,280 @@
+"""Tests for build_eagle3_block_mask -- the analytical BlockMask builder."""
+import unittest
+import torch
+from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+
+from torchspec.models.ops.flex_attention import (
+    build_eagle3_block_mask,
+    eagle3_block_mask,
+    generate_eagle3_mask,
+)
+
+
+def _mask_to_dense_bool(Q_LEN, KV_LEN, bm, BLOCK_SIZE=128):
+    """Convert a BlockMask to a full (Q_LEN, KV_LEN) bool tensor via mask_mod."""
+    qi = torch.arange(Q_LEN, device="cuda").unsqueeze(1)
+    ki = torch.arange(KV_LEN, device="cuda").unsqueeze(0)
+    b = torch.zeros_like(qi)
+    h = torch.zeros_like(qi)
+    return bm.mask_mod(b, h, qi, ki).bool()
+
+
+class TestBuildEagle3BlockMask(unittest.TestCase):
+
+    def _reference_block_mask(self, Q_LEN, KV_LEN, B=1, H=1, device="cuda"):
+        seq_lengths = torch.tensor([Q_LEN] * B, device=device, dtype=torch.int32)
+        mask_mod = generate_eagle3_mask(seq_lengths, Q_LEN, KV_LEN, lck=0)
+        return create_block_mask(mask_mod, B=B, H=H, Q_LEN=Q_LEN, KV_LEN=KV_LEN, device=device)
+
+    def test_mask_pattern_matches_reference_small(self):
+        """Element-level mask pattern must be identical for small sizes."""
+        for n_rounds in [1, 2, 3, 5]:
+            Q_LEN = 256
+            KV_LEN = Q_LEN * n_rounds
+            with self.subTest(rounds=n_rounds):
+                ref = self._reference_block_mask(Q_LEN, KV_LEN)
+                ours = build_eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
+                ref_dense = _mask_to_dense_bool(Q_LEN, KV_LEN, ref)
+                our_dense = _mask_to_dense_bool(Q_LEN, KV_LEN, ours)
+                self.assertTrue(torch.equal(ref_dense, our_dense),
+                    f"Mask pattern mismatch at rounds={n_rounds}")
+
+    def test_mask_pattern_matches_reference_medium(self):
+        """Test at 1024 tokens with multiple rounds."""
+        for n_rounds in [1, 2, 4]:
+            Q_LEN = 1024
+            KV_LEN = Q_LEN * n_rounds
+            with self.subTest(rounds=n_rounds):
+                ref = self._reference_block_mask(Q_LEN, KV_LEN)
+                ours = build_eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
+                ref_dense = _mask_to_dense_bool(Q_LEN, KV_LEN, ref)
+                our_dense = _mask_to_dense_bool(Q_LEN, KV_LEN, ours)
+                self.assertTrue(torch.equal(ref_dense, our_dense))
+
+    def test_batch_size_broadcast(self):
+        """H=1 mask should work with multi-head attention via broadcast."""
+        Q_LEN, KV_LEN = 256, 768
+        bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=2, H=1, device="cuda")
+        self.assertEqual(bm.kv_num_blocks.shape[0], 2)
+        self.assertEqual(bm.kv_num_blocks.shape[1], 1)
+
+    def test_flex_attention_output_matches(self):
+        """flex_attention output must match between analytical and reference mask."""
+        torch.manual_seed(42)
+        B, H, D = 1, 4, 64
+        Q_LEN = 512
+        for n_rounds in [1, 2, 3]:
+            KV_LEN = Q_LEN * n_rounds
+            with self.subTest(rounds=n_rounds):
+                q = torch.randn(B, H, Q_LEN, D, device="cuda", dtype=torch.bfloat16)
+                k = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.bfloat16)
+                v = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.bfloat16)
+
+                ref_bm = self._reference_block_mask(Q_LEN, KV_LEN)
+                our_bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=B, H=1, device="cuda")
+
+                out_ref = flex_attention(q, k, v, block_mask=ref_bm, enable_gqa=False)
+                out_ours = flex_attention(q, k, v, block_mask=our_bm, enable_gqa=False)
+
+                self.assertEqual(out_ref.shape, out_ours.shape)
+                self.assertFalse(out_ours.isnan().any())
+                max_diff = (out_ref - out_ours).abs().max().item()
+                self.assertAlmostEqual(max_diff, 0.0, places=5,
+                    msg=f"Output diff={max_diff} at rounds={n_rounds}")
+
+    def test_flex_attention_gqa(self):
+        """Test with GQA (fewer KV heads than Q heads)."""
+        torch.manual_seed(42)
+        B, Q_HEADS, KV_HEADS, D = 1, 8, 2, 64
+        Q_LEN, KV_LEN = 256, 768
+
+        q = torch.randn(B, Q_HEADS, Q_LEN, D, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(B, KV_HEADS, KV_LEN, D, device="cuda", dtype=torch.bfloat16)
+        v = torch.randn(B, KV_HEADS, KV_LEN, D, device="cuda", dtype=torch.bfloat16)
+
+        bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=B, H=1, device="cuda")
+        out = flex_attention(q, k, v, block_mask=bm, enable_gqa=True)
+
+        self.assertEqual(out.shape, (B, Q_HEADS, Q_LEN, D))
+        self.assertFalse(out.isnan().any())
+
+    def test_backward_pass(self):
+        """Gradients must flow through flex_attention with analytical mask."""
+        torch.manual_seed(42)
+        B, H, D = 1, 4, 64
+        Q_LEN, KV_LEN = 256, 768
+
+        q = torch.randn(B, H, Q_LEN, D, device="cuda", dtype=torch.float32, requires_grad=True)
+        k = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.float32, requires_grad=True)
+        v = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.float32, requires_grad=True)
+
+        bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=B, H=1, device="cuda")
+        out = flex_attention(q, k, v, block_mask=bm, enable_gqa=False)
+        out.sum().backward()
+
+        for name, t in [("q", q), ("k", k), ("v", v)]:
+            self.assertIsNotNone(t.grad, f"{name}.grad is None")
+            self.assertFalse(t.grad.isnan().any(), f"{name}.grad has NaN")
+
+    def test_backward_gradients_match_reference(self):
+        """Gradients must match between analytical and reference masks."""
+        torch.manual_seed(42)
+        B, H, D = 1, 4, 64
+        Q_LEN, KV_LEN = 256, 768
+
+        q1 = torch.randn(B, H, Q_LEN, D, device="cuda", dtype=torch.float32, requires_grad=True)
+        k1 = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.float32, requires_grad=True)
+        v1 = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.float32, requires_grad=True)
+        q2, k2, v2 = [t.clone().detach().requires_grad_(True) for t in (q1, k1, v1)]
+
+        ref_bm = self._reference_block_mask(Q_LEN, KV_LEN)
+        our_bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=B, H=1, device="cuda")
+
+        flex_attention(q1, k1, v1, block_mask=ref_bm, enable_gqa=False).sum().backward()
+        flex_attention(q2, k2, v2, block_mask=our_bm, enable_gqa=False).sum().backward()
+
+        for name, g1, g2 in [("q", q1.grad, q2.grad), ("k", k1.grad, k2.grad), ("v", v1.grad, v2.grad)]:
+            max_diff = (g1 - g2).abs().max().item()
+            self.assertAlmostEqual(max_diff, 0.0, places=4,
+                msg=f"Gradient mismatch for {name}: max_diff={max_diff}")
+
+    def test_causal_only_single_round(self):
+        """With KV_LEN == Q_LEN (1 round), mask should be purely causal."""
+        Q_LEN = 256
+        bm = build_eagle3_block_mask(Q_LEN, Q_LEN, B=1, H=1, device="cuda")
+        dense = _mask_to_dense_bool(Q_LEN, Q_LEN, bm)
+
+        # Lower triangular
+        expected = torch.tril(torch.ones(Q_LEN, Q_LEN, device="cuda", dtype=torch.bool))
+        self.assertTrue(torch.equal(dense, expected), "Single round should be purely causal")
+
+    def test_suffix_diagonal_structure(self):
+        """Suffix rounds should have exactly one active element per row (diagonal)."""
+        Q_LEN = 256
+        KV_LEN = 256 * 3  # 3 rounds: 1 causal + 2 suffix
+        bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
+        dense = _mask_to_dense_bool(Q_LEN, KV_LEN, bm)
+
+        # Check suffix region (kv_idx >= Q_LEN)
+        suffix_mask = dense[:, Q_LEN:]  # (Q_LEN, 2*Q_LEN)
+        for qi in range(Q_LEN):
+            active_kv = suffix_mask[qi].nonzero().squeeze(-1)
+            # Should have exactly 2 active positions (one per suffix round)
+            self.assertEqual(active_kv.numel(), 2,
+                f"Row {qi}: expected 2 suffix positions, got {active_kv.numel()}")
+
+    def test_memory_is_negligible(self):
+        """Analytical builder should use negligible memory."""
+        Q_LEN, KV_LEN = 4096, 4096 * 5
+        torch.cuda.reset_peak_memory_stats()
+        before = torch.cuda.memory_allocated()
+        bm = build_eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
+        after = torch.cuda.max_memory_allocated()
+        mem_mb = (after - before) / 1024**2
+        self.assertLess(mem_mb, 10.0,
+            f"Block mask used {mem_mb:.1f} MB -- should be negligible")
+
+    def test_assertion_on_non_divisible(self):
+        """Should raise if Q_LEN or KV_LEN not divisible by BLOCK_SIZE."""
+        with self.assertRaises(AssertionError):
+            build_eagle3_block_mask(100, 300, B=1, H=1, device="cuda")
+
+    def test_assertion_on_non_round_aligned_kv(self):
+        """Should raise if KV_LEN is not an integer multiple of Q_LEN."""
+        # 256-aligned to BLOCK_SIZE but KV_LEN % Q_LEN != 0.
+        with self.assertRaises(AssertionError):
+            build_eagle3_block_mask(256, 384, B=1, H=1, device="cuda")
+
+
+class TestEagle3BlockMaskDispatcher(unittest.TestCase):
+    """Tests for the eagle3_block_mask dispatcher (analytical + fallback)."""
+
+    def _ref_dense(self, Q_LEN, KV_LEN, bm):
+        qi = torch.arange(Q_LEN, device="cuda").unsqueeze(1)
+        ki = torch.arange(KV_LEN, device="cuda").unsqueeze(0)
+        b = torch.zeros_like(qi)
+        h = torch.zeros_like(qi)
+        return bm.mask_mod(b, h, qi, ki).bool()
+
+    def test_dispatcher_picks_analytical_path(self):
+        """When Q_LEN aligned & KV_LEN % Q_LEN == 0, output must equal analytical builder."""
+        Q_LEN, KV_LEN = 256, 256 * 3
+        dispatched = eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
+        analytical = build_eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
+        # Same kv_indices/q_indices structure indicates analytical path was taken.
+        self.assertTrue(torch.equal(dispatched.kv_num_blocks, analytical.kv_num_blocks))
+        self.assertTrue(torch.equal(dispatched.kv_indices, analytical.kv_indices))
+        self.assertTrue(torch.equal(dispatched.q_num_blocks, analytical.q_num_blocks))
+        self.assertTrue(torch.equal(dispatched.q_indices, analytical.q_indices))
+
+    def test_dispatcher_first_round_uses_analytical(self):
+        """First round (KV_LEN == Q_LEN) is now handled by the analytical builder."""
+        Q_LEN = 256
+        dispatched = eagle3_block_mask(Q_LEN, Q_LEN, B=1, H=1, device="cuda")
+        analytical = build_eagle3_block_mask(Q_LEN, Q_LEN, B=1, H=1, device="cuda")
+        self.assertTrue(torch.equal(dispatched.kv_indices, analytical.kv_indices))
+
+    def test_dispatcher_falls_back_when_q_too_small(self):
+        """When Q_LEN < BLOCK_SIZE, must fall back to create_block_mask without raising."""
+        Q_LEN, KV_LEN = 64, 64
+        bm = eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
+        # Should produce a causal-only mask and not raise.
+        dense = self._ref_dense(Q_LEN, KV_LEN, bm)
+        expected = torch.tril(torch.ones(Q_LEN, KV_LEN, device="cuda", dtype=torch.bool))
+        self.assertTrue(torch.equal(dense, expected))
+
+    def test_dispatcher_falls_back_when_kv_not_round_multiple(self):
+        """When KV_LEN % Q_LEN != 0, must fall back rather than raising the assert."""
+        # 256 and 384 are both multiples of 128 but 384 % 256 != 0, so analytical
+        # path's diagonal layout would be wrong: dispatcher must take the fallback.
+        Q_LEN, KV_LEN = 256, 384
+        bm = eagle3_block_mask(Q_LEN, KV_LEN, B=1, H=1, device="cuda")
+        # Mask correctness is verified element-wise against the canonical mask_mod.
+        seq_lengths = torch.tensor([Q_LEN], device="cuda", dtype=torch.int32)
+        ref_mod = generate_eagle3_mask(seq_lengths, Q_LEN, KV_LEN, lck=0)
+        qi = torch.arange(Q_LEN, device="cuda").unsqueeze(1)
+        ki = torch.arange(KV_LEN, device="cuda").unsqueeze(0)
+        b = torch.zeros_like(qi)
+        h = torch.zeros_like(qi)
+        expected = ref_mod(b, h, qi, ki).bool()
+        actual = bm.mask_mod(b, h, qi, ki).bool()
+        self.assertTrue(torch.equal(actual, expected))
+
+    def test_dispatcher_flex_attention_matches_reference(self):
+        """flex_attention output via dispatcher must match the create_block_mask reference."""
+        torch.manual_seed(42)
+        B, H, D = 1, 4, 64
+        for Q_LEN, KV_LEN in [(256, 256), (256, 256 * 3), (512, 512 * 4)]:
+            with self.subTest(Q_LEN=Q_LEN, KV_LEN=KV_LEN):
+                q = torch.randn(B, H, Q_LEN, D, device="cuda", dtype=torch.bfloat16)
+                k = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.bfloat16)
+                v = torch.randn(B, H, KV_LEN, D, device="cuda", dtype=torch.bfloat16)
+
+                seq_lengths = torch.tensor([Q_LEN] * B, device="cuda", dtype=torch.int32)
+                ref_bm = create_block_mask(
+                    generate_eagle3_mask(seq_lengths, Q_LEN, KV_LEN, lck=0),
+                    B=B, H=1, Q_LEN=Q_LEN, KV_LEN=KV_LEN, device="cuda",
+                )
+                dispatched_bm = eagle3_block_mask(
+                    Q_LEN, KV_LEN, B=B, H=1, device="cuda",
+                )
+
+                out_ref = flex_attention(q, k, v, block_mask=ref_bm, enable_gqa=False)
+                out_disp = flex_attention(q, k, v, block_mask=dispatched_bm, enable_gqa=False)
+                self.assertEqual(out_ref.shape, out_disp.shape)
+                max_diff = (out_ref - out_disp).abs().max().item()
+                self.assertAlmostEqual(max_diff, 0.0, places=5,
+                    msg=f"Output diff={max_diff} at Q={Q_LEN}, KV={KV_LEN}")
+
+    def test_dispatcher_seq_lengths_optional(self):
+        """seq_lengths is optional; analytical path ignores it, fallback synthesises a default."""
+        # Analytical path: no seq_lengths required.
+        bm1 = eagle3_block_mask(256, 768, B=1, H=1, device="cuda")
+        self.assertEqual(bm1.kv_indices.shape[0], 1)
+        # Fallback path: omitted seq_lengths must not raise.
+        bm2 = eagle3_block_mask(64, 64, B=1, H=1, device="cuda")
+        self.assertIsNotNone(bm2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -252,18 +252,16 @@ class TestEagle3FlexMask(unittest.TestCase):
         query = norm_tensor((B, H, S, D), device="cuda", dtype=data_type)
         key_cache = norm_tensor((B, H, KV_LEN, D), device="cuda", dtype=data_type)
         value_cache = norm_tensor((B, H, KV_LEN, D), device="cuda", dtype=data_type)
-        seq_lengths = torch.tensor([S], device="cuda", dtype=torch.int32)
-        seq_lengths -= lck
         block_mask = compile_friendly_create_block_mask(
-            mask_mod=generate_eagle3_mask(
-                seq_lengths=seq_lengths, Q_LEN=Q_LEN, KV_LEN=KV_LEN, lck=lck
-            ),
+            mask_mod=generate_eagle3_mask(Q_LEN=Q_LEN, KV_LEN=KV_LEN, lck=lck),
             B=1,
             H=1,
             Q_LEN=Q_LEN,
             KV_LEN=KV_LEN,
             device=query.device,
         )
+        # PR #91 simplified generate_eagle3_mask to drop seq_lengths-aware shrinking;
+        # the mask is now the full causal+suffix pattern at every q row.
         # fmt: off
         expected_mask = torch.tensor([[[
             [1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
@@ -272,8 +270,8 @@ class TestEagle3FlexMask(unittest.TestCase):
             [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
             [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
             [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+            [1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1],
         ]]], dtype=torch.int32).to(query.device)
         # fmt: on
         dense_mask = block_mask.to_dense()

--- a/torchspec/models/draft/deepseek_eagle.py
+++ b/torchspec/models/draft/deepseek_eagle.py
@@ -419,10 +419,6 @@ class DeepSeekMLAFlexAttention(DeepSeekMLAAttention):
             key_cache = key_states
             value_cache = value_states
 
-        # Build EAGLE3 block mask from attention_mask (seq_lengths)
-        seq_lengths = attention_mask.sum(dim=-1)
-        seq_lengths -= lck
-
         flex_attention_func = flex_attention if q_len <= 128 else compile_friendly_flex_attention
 
         block_mask = eagle3_block_mask(
@@ -431,7 +427,6 @@ class DeepSeekMLAFlexAttention(DeepSeekMLAAttention):
             B=bsz,
             H=1,  # Rely on broadcast
             device=query_states.device,
-            seq_lengths=seq_lengths,
             lck=lck,
         )
 

--- a/torchspec/models/draft/deepseek_eagle.py
+++ b/torchspec/models/draft/deepseek_eagle.py
@@ -27,7 +27,7 @@ from typing import Optional, Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+from torch.nn.attention.flex_attention import flex_attention
 from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
 
 from torchspec.models.draft.base import Eagle3DraftModel
@@ -50,9 +50,8 @@ from torchspec.models.draft.llama3_eagle import (
     yarn_get_mscale,
 )
 from torchspec.models.ops.flex_attention import (
-    compile_friendly_create_block_mask,
     compile_friendly_flex_attention,
-    generate_eagle3_mask,
+    eagle3_block_mask,
 )
 from torchspec.utils.logging import logger, print_with_rank
 
@@ -387,7 +386,8 @@ class DeepSeekMLAFlexAttention(DeepSeekMLAAttention):
       cache_keys:   [B, H, total_seq, qk_head_dim]
       cache_values: [B, H, total_seq, v_head_dim]
 
-    EAGLE3 mask pattern is handled by generate_eagle3_mask + create_block_mask.
+    EAGLE3 mask pattern is handled by eagle3_block_mask (analytical when shapes
+    align to BLOCK_SIZE/Q_LEN, create_block_mask fallback otherwise).
     """
 
     def forward(
@@ -423,25 +423,16 @@ class DeepSeekMLAFlexAttention(DeepSeekMLAAttention):
         seq_lengths = attention_mask.sum(dim=-1)
         seq_lengths -= lck
 
-        if q_len <= 128:
-            create_block_mask_func = create_block_mask
-            flex_attention_func = flex_attention
-        else:
-            create_block_mask_func = compile_friendly_create_block_mask
-            flex_attention_func = compile_friendly_flex_attention
+        flex_attention_func = flex_attention if q_len <= 128 else compile_friendly_flex_attention
 
-        block_mask = create_block_mask_func(
-            mask_mod=generate_eagle3_mask(
-                seq_lengths=seq_lengths,
-                Q_LEN=q_len,
-                KV_LEN=key_cache.shape[-2],
-                lck=lck,
-            ),
-            B=bsz,
-            H=1,  # Rely on broadcast
+        block_mask = eagle3_block_mask(
             Q_LEN=q_len,
             KV_LEN=key_cache.shape[-2],
+            B=bsz,
+            H=1,  # Rely on broadcast
             device=query_states.device,
+            seq_lengths=seq_lengths,
+            lck=lck,
         )
 
         attn_output = flex_attention_func(

--- a/torchspec/models/draft/llama3_eagle.py
+++ b/torchspec/models/draft/llama3_eagle.py
@@ -937,9 +937,7 @@ def _build_eagle3_mask_pair(
         raise ValueError(f"Unknown eagle3 mask mode {mode!r}")
 
     # Always build a flex-compatible mask_mod for block-sparse iteration.
-    seq_lengths = torch.full((bsz,), q_len, dtype=torch.long, device=device)
     mask_mod_flex = generate_eagle3_mask(
-        seq_lengths=seq_lengths,
         Q_LEN=q_len,
         KV_LEN=kv_len,
         lck=lck,
@@ -1406,10 +1404,6 @@ class LlamaFlexAttention(LlamaAttention):
             key_cache = key_states
             value_cache = value_states
 
-        seq_lengths = attention_mask.sum(dim=-1)
-        # Shrink the attention mask to align with the padding to the right.
-        # This is equivalent to the shrinking logic in eagle3.py
-        seq_lengths -= lck
         flex_attention_func = flex_attention if q_len <= 128 else compile_friendly_flex_attention
 
         block_mask = eagle3_block_mask(
@@ -1418,7 +1412,6 @@ class LlamaFlexAttention(LlamaAttention):
             B=bsz,
             H=1,  # Rely on broadcast
             device=query_states.device,
-            seq_lengths=seq_lengths,
             lck=lck,
         )
         attn_output = flex_attention_func(

--- a/torchspec/models/draft/llama3_eagle.py
+++ b/torchspec/models/draft/llama3_eagle.py
@@ -30,8 +30,8 @@ from transformers.models.llama.configuration_llama import LlamaConfig
 
 from torchspec.models.draft.base import Eagle3DraftModel
 from torchspec.models.ops.flex_attention import (
-    compile_friendly_create_block_mask,
     compile_friendly_flex_attention,
+    eagle3_block_mask,
     generate_eagle3_mask,
 )
 from torchspec.utils.logging import logger, print_with_rank
@@ -1410,27 +1410,16 @@ class LlamaFlexAttention(LlamaAttention):
         # Shrink the attention mask to align with the padding to the right.
         # This is equivalent to the shrinking logic in eagle3.py
         seq_lengths -= lck
-        # TODO: Remove the usage of uncompiled create_block_mask after
-        # https://github.com/pytorch/pytorch/issues/160018
-        if q_len <= 128:
-            create_block_mask_func = create_block_mask
-            flex_attention_func = flex_attention
-        else:
-            create_block_mask_func = compile_friendly_create_block_mask
-            flex_attention_func = compile_friendly_flex_attention
+        flex_attention_func = flex_attention if q_len <= 128 else compile_friendly_flex_attention
 
-        block_mask = create_block_mask_func(
-            mask_mod=generate_eagle3_mask(
-                seq_lengths=seq_lengths,
-                Q_LEN=q_len,
-                KV_LEN=key_cache.shape[-2],
-                lck=lck,
-            ),
-            B=bsz,
-            H=1,  # Rely on broadcast
+        block_mask = eagle3_block_mask(
             Q_LEN=q_len,
             KV_LEN=key_cache.shape[-2],
+            B=bsz,
+            H=1,  # Rely on broadcast
             device=query_states.device,
+            seq_lengths=seq_lengths,
+            lck=lck,
         )
         attn_output = flex_attention_func(
             query=query_states,

--- a/torchspec/models/ops/__init__.py
+++ b/torchspec/models/ops/__init__.py
@@ -19,16 +19,20 @@
 # SOFTWARE.
 
 from torchspec.models.ops.flex_attention import (
+    build_eagle3_block_mask,
     compile_friendly_create_block_mask,
     compile_friendly_flex_attention,
+    eagle3_block_mask,
     generate_eagle3_mask,
 )
 from torchspec.models.ops.loss import compiled_forward_kl_loss
 from torchspec.models.ops.loss_mask import compute_assistant_loss_mask
 
 __all__ = [
+    "build_eagle3_block_mask",
     "compile_friendly_create_block_mask",
     "compile_friendly_flex_attention",
+    "eagle3_block_mask",
     "generate_eagle3_mask",
     "compiled_forward_kl_loss",
     "compute_assistant_loss_mask",

--- a/torchspec/models/ops/flex_attention.py
+++ b/torchspec/models/ops/flex_attention.py
@@ -116,8 +116,16 @@ def compile_friendly_create_block_mask(
     )
 
 
-def generate_eagle3_mask(seq_lengths: torch.Tensor, Q_LEN: int, KV_LEN: int, lck: int = 0):
-    """Return a mask_mod for the Eagle3 causal+suffix pattern."""
+def generate_eagle3_mask(Q_LEN: int, KV_LEN: int, lck: int = 0):
+    """Eagle3 causal+suffix mask_mod.
+
+    Note: to support packed sequences (multiple variable-length samples
+    concatenated into one row), seq_lengths must be passed in here so the
+    mask can clamp causal and suffix clauses to per-sample boundaries; for
+    the current single-sample-per-row case the legacy seq_lengths clauses
+    are tautological on every valid q row and are omitted.
+    """
+
     def causal_mask(b, h, q_idx, kv_idx):
         return q_idx >= kv_idx
 
@@ -129,6 +137,77 @@ def generate_eagle3_mask(seq_lengths: torch.Tensor, Q_LEN: int, KV_LEN: int, lck
     return mask_mod
 
 
+def _build_eagle3_block_mask_tensors(
+    Q_LEN: int,
+    KV_LEN: int,
+    B: int,
+    H: int,
+    BLOCK_SIZE: int,
+    device: torch.device,
+):
+    """Return (kv_num, kv_idx, q_num, q_idx) for the Eagle3 BlockMask.
+
+    Split out from BlockMask wrapping so it can be torch.compile'd: BlockMask
+    carries Python-side closures and cannot be a compiled-graph return value.
+    """
+    n_q = Q_LEN // BLOCK_SIZE
+    n_kv = KV_LEN // BLOCK_SIZE
+    n_rounds = KV_LEN // Q_LEN
+
+    # Row qi attends to causal cols 0..qi and one diagonal col per suffix round
+    # at (col-qi)*n_q + qi; total qi + n_rounds entries per row.
+    max_kv_per_row = n_q + n_rounds - 1
+    qi = torch.arange(n_q, device=device, dtype=torch.int32)
+    col = torch.arange(max_kv_per_row, device=device, dtype=torch.int32)
+    qi_b = qi.unsqueeze(1)
+    col_b = col.unsqueeze(0)
+    is_causal = col_b <= qi_b
+    causal_kv = col_b.expand(n_q, max_kv_per_row)
+    suffix_kv = (col_b - qi_b) * n_q + qi_b
+    kv_idx_2d = torch.where(is_causal, causal_kv, suffix_kv)
+    valid = col_b < (qi_b + n_rounds)
+    kv_idx_2d = torch.where(valid, kv_idx_2d, torch.zeros_like(kv_idx_2d))
+    kv_num_1d = (qi + n_rounds).to(torch.int32)
+
+    # Column ki: r=ki//n_q, pos=ki%n_q. r==0 -> q in [pos, n_q); r>=1 -> q==pos.
+    max_q_per_col = n_q
+    ki = torch.arange(n_kv, device=device, dtype=torch.int32)
+    col_q = torch.arange(max_q_per_col, device=device, dtype=torch.int32)
+    r = ki // n_q
+    pos = ki % n_q
+    r_b = r.unsqueeze(1)
+    pos_b = pos.unsqueeze(1)
+    col_q_b = col_q.unsqueeze(0)
+    q_idx_2d = torch.where(r_b == 0, pos_b + col_q_b, pos_b.expand(n_kv, max_q_per_col))
+    q_num_1d = torch.where(r == 0, n_q - pos, torch.ones_like(pos)).to(torch.int32)
+    valid_q = col_q_b < q_num_1d.unsqueeze(1)
+    q_idx_2d = torch.where(valid_q, q_idx_2d, torch.zeros_like(q_idx_2d))
+
+    # flex_attention iterates these directly; force contiguous storage.
+    kv_num = kv_num_1d.unsqueeze(0).unsqueeze(0).expand(B, H, n_q).contiguous()
+    kv_idx = kv_idx_2d.unsqueeze(0).unsqueeze(0).expand(B, H, n_q, max_kv_per_row).contiguous()
+    q_num = q_num_1d.unsqueeze(0).unsqueeze(0).expand(B, H, n_kv).contiguous()
+    q_idx = q_idx_2d.unsqueeze(0).unsqueeze(0).expand(B, H, n_kv, max_q_per_col).contiguous()
+    return kv_num, kv_idx, q_num, q_idx
+
+
+# dynamic=True so KV_LEN growing per TTT step doesn't recompile; inductor's
+# persistent cache amortises the one-off compile across runs.
+_compiled_build_tensors = None
+
+
+@torch.compiler.disable(recursive=False)
+def _get_compiled_build_tensors():
+    global _compiled_build_tensors
+    if _compiled_build_tensors is None:
+        _compiled_build_tensors = torch.compile(
+            _build_eagle3_block_mask_tensors,
+            dynamic=True,
+            fullgraph=True,
+        )
+    return _compiled_build_tensors
+
+
 def build_eagle3_block_mask(
     Q_LEN: int,
     KV_LEN: int,
@@ -137,60 +216,30 @@ def build_eagle3_block_mask(
     device: torch.device = "cuda",
     BLOCK_SIZE: int = 128,
 ) -> "BlockMask":
-    """Build Eagle3 BlockMask analytically -- O(num_blocks) memory.
+    """Build Eagle3 BlockMask analytically -- O(num_blocks) memory and time.
 
     create_block_mask materialises the full (Q_LEN, KV_LEN) boolean grid
-    internally (~112 GB at Q=49K, KV=245K).  This function constructs the
-    sparse kv_indices and q_indices tensors directly from the known Eagle3
-    mask structure (causal first round + diagonal suffix rounds), reducing
-    peak memory to a few MB.
+    (~112 GB at Q=49K, KV=245K). This builds the sparse kv/q indices
+    directly from the known Eagle3 structure (causal first round + diagonal
+    suffix rounds), so peak memory drops to a few MB.
 
-    Requires Q_LEN, KV_LEN to be multiples of BLOCK_SIZE and KV_LEN to be
-    an integer number of Q_LEN-sized rounds.  Use ``eagle3_block_mask``
-    for the dispatching wrapper that falls back to create_block_mask when
-    those preconditions don't hold.
+    Requires Q_LEN, KV_LEN multiples of BLOCK_SIZE and KV_LEN a multiple of
+    Q_LEN. Use ``eagle3_block_mask`` for the dispatching wrapper that falls
+    back to create_block_mask otherwise.
     """
     assert Q_LEN % BLOCK_SIZE == 0 and KV_LEN % BLOCK_SIZE == 0
     assert KV_LEN % Q_LEN == 0, (
         "build_eagle3_block_mask requires KV_LEN to be a multiple of Q_LEN; "
         f"got Q_LEN={Q_LEN}, KV_LEN={KV_LEN}"
     )
-    n_q = Q_LEN // BLOCK_SIZE
-    n_kv = KV_LEN // BLOCK_SIZE
-    n_rounds = KV_LEN // Q_LEN
 
-    # KV blocks per Q row
-    max_kv_per_row = n_q + (n_rounds - 1)
-    kv_num = torch.zeros(B, H, n_q, dtype=torch.int32, device=device)
-    kv_idx = torch.zeros(B, H, n_q, max_kv_per_row, dtype=torch.int32, device=device)
-
-    for qi in range(n_q):
-        col = 0
-        for ki in range(qi + 1):
-            kv_idx[:, :, qi, col] = ki
-            col += 1
-        for r in range(1, n_rounds):
-            kv_idx[:, :, qi, col] = r * n_q + qi
-            col += 1
-        kv_num[:, :, qi] = col
-
-    # Q blocks per KV column (transpose)
-    max_q_per_col = n_q + 1
-    q_num = torch.zeros(B, H, n_kv, dtype=torch.int32, device=device)
-    q_idx = torch.zeros(B, H, n_kv, max_q_per_col, dtype=torch.int32, device=device)
-
-    for ki in range(n_kv):
-        r = ki // n_q
-        pos = ki % n_q
-        col = 0
-        if r == 0:
-            for qi in range(pos, n_q):
-                q_idx[:, :, ki, col] = qi
-                col += 1
-        else:
-            q_idx[:, :, ki, col] = pos
-            col += 1
-        q_num[:, :, ki] = col
+    # Skip the compiled path when nested inside another torch.compile graph.
+    builder = (
+        _build_eagle3_block_mask_tensors
+        if is_torchdynamo_compiling()
+        else _get_compiled_build_tensors()
+    )
+    kv_num, kv_idx, q_num, q_idx = builder(Q_LEN, KV_LEN, B, H, BLOCK_SIZE, device)
 
     def mask_mod(b, h, q, kv):
         causal = (kv < Q_LEN) & (q >= kv)
@@ -220,7 +269,6 @@ def eagle3_block_mask(
     H: int = 1,
     device: torch.device = "cuda",
     BLOCK_SIZE: int = 128,
-    seq_lengths: torch.Tensor = None,
     lck: int = 0,
 ) -> "BlockMask":
     """Eagle3 block-mask dispatcher -- analytical when possible, fallback otherwise.
@@ -239,9 +287,6 @@ def eagle3_block_mask(
         H: head count for the BlockMask (broadcast-friendly when 1).
         device: target device.
         BLOCK_SIZE: flex_attention block size; defaults to 128.
-        seq_lengths: per-batch sequence lengths.  Currently unused by the
-            Eagle3 mask closure but accepted to mirror the legacy call site
-            signature, and reserved for future variable-length variants.
         lck: number of completed rounds; only used to name the fallback
             mask_mod for debug clarity.
 
@@ -249,11 +294,7 @@ def eagle3_block_mask(
         A flex_attention BlockMask implementing the Eagle3 causal+suffix
         pattern.
     """
-    use_analytical = (
-        Q_LEN % BLOCK_SIZE == 0
-        and KV_LEN % BLOCK_SIZE == 0
-        and KV_LEN % Q_LEN == 0
-    )
+    use_analytical = Q_LEN % BLOCK_SIZE == 0 and KV_LEN % BLOCK_SIZE == 0 and KV_LEN % Q_LEN == 0
     if use_analytical:
         return build_eagle3_block_mask(
             Q_LEN=Q_LEN,
@@ -265,20 +306,11 @@ def eagle3_block_mask(
         )
 
     # Fallback for non-aligned shapes (typically only seen in tests).
-    # generate_eagle3_mask's closure does not consume seq_lengths today, so
-    # synthesise a reasonable default when the caller didn't supply one.
     # TODO: Remove the usage of uncompiled create_block_mask after
     # https://github.com/pytorch/pytorch/issues/160018
     creator = create_block_mask if Q_LEN <= 128 else compile_friendly_create_block_mask
-    if seq_lengths is None:
-        seq_lengths = torch.full((B,), KV_LEN, dtype=torch.int32, device=device)
     return creator(
-        mask_mod=generate_eagle3_mask(
-            seq_lengths=seq_lengths,
-            Q_LEN=Q_LEN,
-            KV_LEN=KV_LEN,
-            lck=lck,
-        ),
+        mask_mod=generate_eagle3_mask(Q_LEN=Q_LEN, KV_LEN=KV_LEN, lck=lck),
         B=B,
         H=H,
         Q_LEN=Q_LEN,

--- a/torchspec/models/ops/flex_attention.py
+++ b/torchspec/models/ops/flex_attention.py
@@ -22,6 +22,7 @@ import torch
 import torch._dynamo as dynamo
 import torch._inductor.config as inductor_config
 from torch.nn.attention.flex_attention import (
+    BlockMask,
     create_block_mask,
     flex_attention,
     or_masks,
@@ -116,19 +117,171 @@ def compile_friendly_create_block_mask(
 
 
 def generate_eagle3_mask(seq_lengths: torch.Tensor, Q_LEN: int, KV_LEN: int, lck: int = 0):
+    """Return a mask_mod for the Eagle3 causal+suffix pattern."""
     def causal_mask(b, h, q_idx, kv_idx):
-        # Causal will keep shrinking by 1 diagnol due to appended suffix
-        # Shirnk the causal by diagnol
-        causal_mask = q_idx >= kv_idx
-        padding_mask = (kv_idx < seq_lengths[b]) & (q_idx < seq_lengths[b])
-        return causal_mask & padding_mask
+        return q_idx >= kv_idx
 
     def suffix_mask(b, h, q_idx, kv_idx):
-        suffix_mask = kv_idx >= Q_LEN
-        padding_mask = kv_idx % Q_LEN < seq_lengths[b]
-        diagnol_mask = (kv_idx - q_idx) % Q_LEN == 0
-        return suffix_mask & padding_mask & diagnol_mask
+        return (kv_idx >= Q_LEN) & ((kv_idx - q_idx) % Q_LEN == 0)
 
     mask_mod = or_masks(causal_mask, suffix_mask)
     mask_mod.__name__ = f"eagle3_mask_Q_{Q_LEN}_KV_{KV_LEN}_lck_{lck}"
     return mask_mod
+
+
+def build_eagle3_block_mask(
+    Q_LEN: int,
+    KV_LEN: int,
+    B: int = 1,
+    H: int = 1,
+    device: torch.device = "cuda",
+    BLOCK_SIZE: int = 128,
+) -> "BlockMask":
+    """Build Eagle3 BlockMask analytically -- O(num_blocks) memory.
+
+    create_block_mask materialises the full (Q_LEN, KV_LEN) boolean grid
+    internally (~112 GB at Q=49K, KV=245K).  This function constructs the
+    sparse kv_indices and q_indices tensors directly from the known Eagle3
+    mask structure (causal first round + diagonal suffix rounds), reducing
+    peak memory to a few MB.
+
+    Requires Q_LEN, KV_LEN to be multiples of BLOCK_SIZE and KV_LEN to be
+    an integer number of Q_LEN-sized rounds.  Use ``eagle3_block_mask``
+    for the dispatching wrapper that falls back to create_block_mask when
+    those preconditions don't hold.
+    """
+    assert Q_LEN % BLOCK_SIZE == 0 and KV_LEN % BLOCK_SIZE == 0
+    assert KV_LEN % Q_LEN == 0, (
+        "build_eagle3_block_mask requires KV_LEN to be a multiple of Q_LEN; "
+        f"got Q_LEN={Q_LEN}, KV_LEN={KV_LEN}"
+    )
+    n_q = Q_LEN // BLOCK_SIZE
+    n_kv = KV_LEN // BLOCK_SIZE
+    n_rounds = KV_LEN // Q_LEN
+
+    # KV blocks per Q row
+    max_kv_per_row = n_q + (n_rounds - 1)
+    kv_num = torch.zeros(B, H, n_q, dtype=torch.int32, device=device)
+    kv_idx = torch.zeros(B, H, n_q, max_kv_per_row, dtype=torch.int32, device=device)
+
+    for qi in range(n_q):
+        col = 0
+        for ki in range(qi + 1):
+            kv_idx[:, :, qi, col] = ki
+            col += 1
+        for r in range(1, n_rounds):
+            kv_idx[:, :, qi, col] = r * n_q + qi
+            col += 1
+        kv_num[:, :, qi] = col
+
+    # Q blocks per KV column (transpose)
+    max_q_per_col = n_q + 1
+    q_num = torch.zeros(B, H, n_kv, dtype=torch.int32, device=device)
+    q_idx = torch.zeros(B, H, n_kv, max_q_per_col, dtype=torch.int32, device=device)
+
+    for ki in range(n_kv):
+        r = ki // n_q
+        pos = ki % n_q
+        col = 0
+        if r == 0:
+            for qi in range(pos, n_q):
+                q_idx[:, :, ki, col] = qi
+                col += 1
+        else:
+            q_idx[:, :, ki, col] = pos
+            col += 1
+        q_num[:, :, ki] = col
+
+    def mask_mod(b, h, q, kv):
+        causal = (kv < Q_LEN) & (q >= kv)
+        suffix = (kv >= Q_LEN) & ((kv - q) % Q_LEN == 0)
+        return causal | suffix
+
+    return BlockMask(
+        seq_lengths=(Q_LEN, KV_LEN),
+        kv_num_blocks=kv_num,
+        kv_indices=kv_idx,
+        full_kv_num_blocks=None,
+        full_kv_indices=None,
+        q_num_blocks=q_num,
+        q_indices=q_idx,
+        full_q_num_blocks=None,
+        full_q_indices=None,
+        BLOCK_SIZE=(BLOCK_SIZE, BLOCK_SIZE),
+        mask_mod=mask_mod,
+    )
+
+
+def eagle3_block_mask(
+    Q_LEN: int,
+    KV_LEN: int,
+    *,
+    B: int = 1,
+    H: int = 1,
+    device: torch.device = "cuda",
+    BLOCK_SIZE: int = 128,
+    seq_lengths: torch.Tensor = None,
+    lck: int = 0,
+) -> "BlockMask":
+    """Eagle3 block-mask dispatcher -- analytical when possible, fallback otherwise.
+
+    Eagle3 training appends one full Q_LEN-sized round per step, so in normal
+    training the analytical builder's preconditions
+    ``(Q_LEN % BLOCK_SIZE == 0 and KV_LEN % Q_LEN == 0)`` always hold.  The
+    create_block_mask fallback only triggers for tests/edge cases (tiny
+    sequence lengths, non-aligned shapes), where its O(Q*KV) memory cost is
+    irrelevant.
+
+    Args:
+        Q_LEN: query length (current round).
+        KV_LEN: total KV length (cached + current).
+        B: batch size for the BlockMask (broadcast-friendly when 1).
+        H: head count for the BlockMask (broadcast-friendly when 1).
+        device: target device.
+        BLOCK_SIZE: flex_attention block size; defaults to 128.
+        seq_lengths: per-batch sequence lengths.  Currently unused by the
+            Eagle3 mask closure but accepted to mirror the legacy call site
+            signature, and reserved for future variable-length variants.
+        lck: number of completed rounds; only used to name the fallback
+            mask_mod for debug clarity.
+
+    Returns:
+        A flex_attention BlockMask implementing the Eagle3 causal+suffix
+        pattern.
+    """
+    use_analytical = (
+        Q_LEN % BLOCK_SIZE == 0
+        and KV_LEN % BLOCK_SIZE == 0
+        and KV_LEN % Q_LEN == 0
+    )
+    if use_analytical:
+        return build_eagle3_block_mask(
+            Q_LEN=Q_LEN,
+            KV_LEN=KV_LEN,
+            B=B,
+            H=H,
+            device=device,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+
+    # Fallback for non-aligned shapes (typically only seen in tests).
+    # generate_eagle3_mask's closure does not consume seq_lengths today, so
+    # synthesise a reasonable default when the caller didn't supply one.
+    # TODO: Remove the usage of uncompiled create_block_mask after
+    # https://github.com/pytorch/pytorch/issues/160018
+    creator = create_block_mask if Q_LEN <= 128 else compile_friendly_create_block_mask
+    if seq_lengths is None:
+        seq_lengths = torch.full((B,), KV_LEN, dtype=torch.int32, device=device)
+    return creator(
+        mask_mod=generate_eagle3_mask(
+            seq_lengths=seq_lengths,
+            Q_LEN=Q_LEN,
+            KV_LEN=KV_LEN,
+            lck=lck,
+        ),
+        B=B,
+        H=H,
+        Q_LEN=Q_LEN,
+        KV_LEN=KV_LEN,
+        device=device,
+    )


### PR DESCRIPTION
## Summary

- Add `build_eagle3_block_mask`, an O(num_blocks)-memory direct constructor for the Eagle3 causal+suffix `BlockMask`. `create_block_mask` materialises the full `(Q_LEN, KV_LEN)` boolean grid internally (~112 GB at Q=49K, KV=245K), causing OOM on long-context Eagle3 training. The analytical builder writes the sparse `kv_indices`/`q_indices` tensors directly from the known mask structure, dropping peak memory to a few MB.
- Add `eagle3_block_mask` dispatcher: uses the analytical builder when the preconditions hold (`Q_LEN % BLOCK_SIZE == 0`, `KV_LEN % BLOCK_SIZE == 0`, `KV_LEN % Q_LEN == 0`), otherwise falls back to `create_block_mask` / `compile_friendly_create_block_mask` (covers tests/edge cases where the O(Q*KV) cost is irrelevant).
- Simplify `generate_eagle3_mask` to drop the `seq_lengths`-aware padding mask. It's now only consumed by the dispatcher's fallback path; padding is enforced upstream via the attention mask, and the analytical path gets exact equivalence by construction (verified by tests below).
- Re-export `build_eagle3_block_mask` and `eagle3_block_mask` from `torchspec.models.ops`.

## Testing

New file: `tests/test_build_eagle3_block_mask.py` (18 tests + 13 subtests):

Local run on torch 2.9.1+cu129, single CUDA device:

```
$ pytest tests/test_build_eagle3_block_mask.py -x -q
..................                                          [100%]
18 passed, 1 warning, 13 subtests passed in 7.52s
```

Smoke import check confirms `LlamaFlexAttention` and `DeepSeekMLAFlexAttention` still load with the dispatcher import. No new lints.

Solves https://github.com/lightseekorg/TorchSpec/issues/86
