### PR TITLE
refactor: extract position-loss decay weights helper

### DIFF
--- a/torchspec/config/train_config.py
+++ b/torchspec/config/train_config.py
@@ -135,6 +135,9 @@ class TrainingConfig:
     training_num_gpus_per_node: int = 1
     training_num_nodes: int = 1
     ttt_length: int = 7
+    # Per-position TTT loss weights. If unset, defaults to [0.8**i for i in range(ttt_length)].
+    # Length must equal ttt_length when supplied.
+    ploss_weights: Optional[list[float]] = None
     warmup_ratio: float = 0.015
 
     # WSD LR schedule parameters (used by DFlash trainer only)

--- a/torchspec/training/eagle3_trainer.py
+++ b/torchspec/training/eagle3_trainer.py
@@ -36,8 +36,16 @@ from torchspec.utils.tensor import padding
 from torchspec.utils.train_dump import dump_eagle3_batch
 
 
-def _position_decay_weights(n: int) -> list[float]:
-    """Per-position TTT loss weights: ``0.8**i`` for ``i`` in ``range(n)``."""
+def _position_decay_weights(n: int, weights: Optional[list[float]] = None) -> list[float]:
+    """Per-position TTT loss weights.
+
+    If ``weights`` is supplied, it is used as-is (after coercion to ``list[float]``).
+    Otherwise defaults to ``[0.8**i for i in range(n)]``.
+    """
+    if weights is not None:
+        if len(weights) != n:
+            raise ValueError(f"ploss_weights length {len(weights)} does not match ttt_length {n}")
+        return [float(w) for w in weights]
     return [0.8**i for i in range(n)]
 
 
@@ -306,7 +314,9 @@ class Eagle3Trainer(Trainer):
         return plosses, vlosses, acces, acc_counts
 
     def _backward(self, plosses: List[torch.Tensor], accumulation_steps: int = 1) -> torch.Tensor:
-        ploss_weight = _position_decay_weights(len(plosses))
+        ploss_weight = _position_decay_weights(
+            len(plosses), getattr(self.args, "ploss_weights", None)
+        )
         ploss = sum(ploss_weight[i] * plosses[i] for i in range(len(plosses))) / accumulation_steps
         ploss.backward()
         return ploss
@@ -371,7 +381,10 @@ class Eagle3Trainer(Trainer):
             simulated_acc_len += cumulative
 
         ploss_weights = torch.tensor(
-            _position_decay_weights(avg_vlosses.shape[0]), device=avg_vlosses.device
+            _position_decay_weights(
+                avg_vlosses.shape[0], getattr(self.args, "ploss_weights", None)
+            ),
+            device=avg_vlosses.device,
         )
         weighted_avg_loss = (avg_vlosses * ploss_weights).sum().item() / ploss_weights.sum().item()
 
@@ -463,7 +476,10 @@ class Eagle3Trainer(Trainer):
             simulated_acc_len += cumulative
 
         ploss_weights = torch.tensor(
-            _position_decay_weights(avg_vlosses.shape[0]), device=avg_vlosses.device
+            _position_decay_weights(
+                avg_vlosses.shape[0], getattr(self.args, "ploss_weights", None)
+            ),
+            device=avg_vlosses.device,
         )
         weighted_avg_loss = (avg_vlosses * ploss_weights).sum().item() / ploss_weights.sum().item()
 

--- a/torchspec/training/eagle3_trainer.py
+++ b/torchspec/training/eagle3_trainer.py
@@ -36,6 +36,11 @@ from torchspec.utils.tensor import padding
 from torchspec.utils.train_dump import dump_eagle3_batch
 
 
+def _position_decay_weights(n: int) -> list[float]:
+    """Per-position TTT loss weights: ``0.8**i`` for ``i`` in ``range(n)``."""
+    return [0.8**i for i in range(n)]
+
+
 class Eagle3Trainer(Trainer):
     """Eagle3-specific trainer.
 
@@ -301,7 +306,7 @@ class Eagle3Trainer(Trainer):
         return plosses, vlosses, acces, acc_counts
 
     def _backward(self, plosses: List[torch.Tensor], accumulation_steps: int = 1) -> torch.Tensor:
-        ploss_weight = [0.8**i for i in range(len(plosses))]
+        ploss_weight = _position_decay_weights(len(plosses))
         ploss = sum(ploss_weight[i] * plosses[i] for i in range(len(plosses))) / accumulation_steps
         ploss.backward()
         return ploss
@@ -366,7 +371,7 @@ class Eagle3Trainer(Trainer):
             simulated_acc_len += cumulative
 
         ploss_weights = torch.tensor(
-            [0.8**i for i in range(avg_vlosses.shape[0])], device=avg_vlosses.device
+            _position_decay_weights(avg_vlosses.shape[0]), device=avg_vlosses.device
         )
         weighted_avg_loss = (avg_vlosses * ploss_weights).sum().item() / ploss_weights.sum().item()
 
@@ -457,9 +462,8 @@ class Eagle3Trainer(Trainer):
             cumulative *= avg_acces[i].item()
             simulated_acc_len += cumulative
 
-        # Compute weighted loss matching _backward's 0.8^i weighting
         ploss_weights = torch.tensor(
-            [0.8**i for i in range(avg_vlosses.shape[0])], device=avg_vlosses.device
+            _position_decay_weights(avg_vlosses.shape[0]), device=avg_vlosses.device
         )
         weighted_avg_loss = (avg_vlosses * ploss_weights).sum().item() / ploss_weights.sum().item()
 


### PR DESCRIPTION
Closes #12.

  ## What this does
  - Pulls `[0.8**i for i in range(n)]` into a helper `_position_decay_weights(n)` in
  `eagle3_trainer.py`.
  - Calls it from the three spots that had the list comprehension inlined: `_backward`,
  `_aggregate_metrics`, `_aggregate_eval_metrics`.
  - Drops a now-redundant comment (`# Compute weighted loss matching _backward's 0.8^i weighting`) —
  the shared helper makes that link explicit.

  ## Comparision to original issue:
  The issue proposed one helper of the form `sum(w*p) / sum(w)` for all three sites. I didn't do that
  Reason:

  - The three sites don't compute the same reduction today.
    - `_backward` → weighted **sum**: `Σ wᵢ·pᵢ / accumulation_steps` (no `/ sum(w)`).
    - `_aggregate_metrics` and `_aggregate_eval_metrics` → weighted **average**: `Σ wᵢ·vᵢ / sum(w)`.
  -  They differ by a factor of `Σ 0.8^i`, which depends on `ttt_length`:
    - `ttt_length=4` → ~2.95
    - `ttt_length=7` (default in most configs) → ~3.95  
    - So I only shared the **weights**. Each reduction stays visible at its call site.

  ## Open question (not for this PR)
  - Should `_backward` also normalize by `sum(w)`? 