### PR TITLE
Fix: when config rope_type is null

### DIFF
--- a/torchspec/models/draft/deepseek_eagle.py
+++ b/torchspec/models/draft/deepseek_eagle.py
@@ -163,7 +163,7 @@ class DeepSeekMLAAttention(nn.Module):
         rope_theta = getattr(self.config, "rope_theta", 10000)
         rget = partial(_rope_config_get, rope_scaling)
         scaling_type = rget("rope_type", rget("type"))
-        
+
         if rope_scaling is None or scaling_type == "default":
             self.rotary_emb = LlamaRotaryEmbedding(
                 rope_dim,

--- a/torchspec/models/draft/deepseek_eagle.py
+++ b/torchspec/models/draft/deepseek_eagle.py
@@ -58,6 +58,8 @@ from torchspec.utils.logging import logger, print_with_rank
 
 def _rope_config_get(rope_scaling, key, default=None):
     """Get a value from rope_scaling config (dict or object)."""
+    if rope_scaling is None:
+        return default
     if isinstance(rope_scaling, dict):
         return rope_scaling.get(key, default)
     return getattr(rope_scaling, key, default)
@@ -159,16 +161,16 @@ class DeepSeekMLAAttention(nn.Module):
         rope_dim = self.qk_rope_head_dim
         rope_scaling = self.config.rope_scaling
         rope_theta = getattr(self.config, "rope_theta", 10000)
-
-        if rope_scaling is None:
+        rget = partial(_rope_config_get, rope_scaling)
+        scaling_type = rget("rope_type", rget("type"))
+        
+        if rope_scaling is None or scaling_type == "default":
             self.rotary_emb = LlamaRotaryEmbedding(
                 rope_dim,
                 max_position_embeddings=self.max_position_embeddings,
                 base=rope_theta,
             )
         else:
-            rget = partial(_rope_config_get, rope_scaling)
-            scaling_type = rget("rope_type", rget("type"))
             scaling_factor = rget("factor")
 
             if scaling_type in (None, "default"):

--- a/torchspec/models/draft/llama3_eagle.py
+++ b/torchspec/models/draft/llama3_eagle.py
@@ -1155,21 +1155,23 @@ class LlamaAttention(nn.Module):
         self._init_rope()
 
     def _init_rope(self):
-        if self.config.rope_scaling is None:
+        rope_scaling = self.config.rope_scaling
+
+        def rope_get(key, default=None):
+            if rope_scaling is None:
+                return default
+            if isinstance(rope_scaling, dict):
+                return rope_scaling.get(key, default)
+            return getattr(rope_scaling, key, default)
+        scaling_type = rope_get("rope_type", rope_get("type"))
+
+        if rope_scaling is None or scaling_type == "default":
             self.rotary_emb = LlamaRotaryEmbedding(
                 self.head_dim,
                 max_position_embeddings=self.max_position_embeddings,
                 base=getattr(self.config, "rope_theta", 10000),
             )
         else:
-            rope_scaling = self.config.rope_scaling
-
-            def rope_get(key, default=None):
-                if isinstance(rope_scaling, dict):
-                    return rope_scaling.get(key, default)
-                return getattr(rope_scaling, key, default)
-
-            scaling_type = rope_get("rope_type", rope_get("type"))
             scaling_factor = rope_get("factor")
 
             if scaling_type == "linear":

--- a/torchspec/models/draft/llama3_eagle.py
+++ b/torchspec/models/draft/llama3_eagle.py
@@ -1163,6 +1163,7 @@ class LlamaAttention(nn.Module):
             if isinstance(rope_scaling, dict):
                 return rope_scaling.get(key, default)
             return getattr(rope_scaling, key, default)
+
         scaling_type = rope_get("rope_type", rope_get("type"))
 
         if rope_scaling is None or scaling_type == "default":


### PR DESCRIPTION
Fix: https://github.com/lightseekorg/TorchSpec/issues/101

When config rope_type is null, but loading after it will update to "default" value, so we need to check.

Update after, we can use `bash ./examples/qwen3-8b-single-node/run.sh` this command to test success.