### PR TITLE
Add default set env MC_STORE_MEMCPY is 0 when protocol is tcp

### DIFF
--- a/tests/test_mooncake_force_delete.py
+++ b/tests/test_mooncake_force_delete.py
@@ -68,6 +68,56 @@ class TestEnableHardPinConfig:
             assert restored.enable_hard_pin is False
 
 
+class TestMooncakeEnvDefaults:
+    def test_tcp_memcpy_default_is_applied_by_export_env(self):
+        config = MooncakeConfig(protocol="tcp")
+
+        with patch.dict(os.environ, {}, clear=True):
+            config.export_env()
+
+            assert os.environ["MC_STORE_MEMCPY"] == "0"
+
+    def test_tcp_memcpy_default_preserves_user_override(self):
+        config = MooncakeConfig(protocol="tcp")
+
+        with patch.dict(os.environ, {"MC_STORE_MEMCPY": "1"}, clear=True):
+            config.apply_env_defaults()
+
+            assert os.environ["MC_STORE_MEMCPY"] == "1"
+
+    def test_tcp_memcpy_default_not_applied_for_rdma(self):
+        config = MooncakeConfig(protocol="rdma")
+
+        with patch.dict(os.environ, {}, clear=True):
+            config.apply_env_defaults()
+
+            assert "MC_STORE_MEMCPY" not in os.environ
+
+    def test_direct_store_setup_applies_tcp_memcpy_before_mooncake_client_setup(self):
+        config = MooncakeConfig(protocol="tcp", async_put_pool_size=0)
+        mock_raw_store = MagicMock()
+        mock_raw_store.setup.return_value = 0
+
+        class ConcreteStore(MooncakeHiddenStateStore):
+            pass
+
+        def make_raw_store():
+            assert os.environ["MC_STORE_MEMCPY"] == "0"
+            return mock_raw_store
+
+        store = ConcreteStore(config)
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("torchspec.transfer.mooncake.store.MooncakeDistributedStore", make_raw_store),
+            patch.object(ConcreteStore, "_verify_force_delete"),
+            patch.object(ConcreteStore, "_build_replicate_config"),
+            patch("torch.cuda.is_available", return_value=False),
+        ):
+            store.setup()
+
+        mock_raw_store.setup.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # Tests 2-3: _verify_force_delete
 # ---------------------------------------------------------------------------

--- a/tests/test_placement_group.py
+++ b/tests/test_placement_group.py
@@ -1,12 +1,11 @@
-from argparse import Namespace
 import importlib.util
 import sys
 import types
+from argparse import Namespace
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 
 repo_root = Path(__file__).resolve().parents[1]
 torchspec_pkg = sys.modules.get("torchspec")
@@ -67,8 +66,8 @@ train_group_stub.RayTrainGroup = object
 sys.modules["torchspec.ray.train_group"] = train_group_stub
 
 from torchspec.ray.placement_group import (  # noqa: E402
-    _NodeConstraint,
     _build_custom_bundles,
+    _NodeConstraint,
     _sort_probed_bundle_infos,
     create_placement_groups,
 )

--- a/torchspec/config/mooncake_config.py
+++ b/torchspec/config/mooncake_config.py
@@ -176,6 +176,11 @@ class MooncakeConfig:
         os.environ["MOONCAKE_PROTOCOL"] = self.protocol
         os.environ["MOONCAKE_DEVICE_NAME"] = self.device_name
         os.environ["MOONCAKE_ENABLE_GPU_DIRECT"] = "1" if self.enable_gpu_direct else "0"
+        # Fix: https://github.com/kvcache-ai/Mooncake/issues/1986
+        if self.protocol.lower() == "tcp" and "MC_STORE_MEMCPY" not in os.environ:
+            # Mooncake's TCP-only memcpy fast path can segfault in same-host
+            # multi-process get paths. Preserve an explicit user override.
+            os.environ["MC_STORE_MEMCPY"] = "0"
         if self.async_put_pool_size is not None:
             os.environ["MOONCAKE_ASYNC_PUT_POOL_SIZE"] = str(self.async_put_pool_size)
         os.environ["MOONCAKE_STORE_FULL_WAIT_SECONDS"] = str(self.store_full_wait_seconds)

--- a/torchspec/config/mooncake_config.py
+++ b/torchspec/config/mooncake_config.py
@@ -176,11 +176,7 @@ class MooncakeConfig:
         os.environ["MOONCAKE_PROTOCOL"] = self.protocol
         os.environ["MOONCAKE_DEVICE_NAME"] = self.device_name
         os.environ["MOONCAKE_ENABLE_GPU_DIRECT"] = "1" if self.enable_gpu_direct else "0"
-        # Fix: https://github.com/kvcache-ai/Mooncake/issues/1986
-        if self.protocol.lower() == "tcp" and "MC_STORE_MEMCPY" not in os.environ:
-            # Mooncake's TCP-only memcpy fast path can segfault in same-host
-            # multi-process get paths. Preserve an explicit user override.
-            os.environ["MC_STORE_MEMCPY"] = "0"
+        self.apply_env_defaults()
         if self.async_put_pool_size is not None:
             os.environ["MOONCAKE_ASYNC_PUT_POOL_SIZE"] = str(self.async_put_pool_size)
         os.environ["MOONCAKE_STORE_FULL_WAIT_SECONDS"] = str(self.store_full_wait_seconds)
@@ -194,6 +190,14 @@ class MooncakeConfig:
         )
         os.environ["MOONCAKE_GET_RETRY_MAX_WAIT_SECONDS"] = str(self.get_retry_max_wait_seconds)
         os.environ["MOONCAKE_ENABLE_HARD_PIN"] = "1" if self.enable_hard_pin else "0"
+
+    def apply_env_defaults(self) -> None:
+        """Apply Mooncake process defaults that are needed before client setup."""
+        # Fix: https://github.com/kvcache-ai/Mooncake/issues/1986
+        if self.protocol.lower() == "tcp" and "MC_STORE_MEMCPY" not in os.environ:
+            # Mooncake's TCP-only memcpy fast path can segfault in same-host
+            # multi-process get paths. Preserve an explicit user override.
+            os.environ["MC_STORE_MEMCPY"] = "0"
 
     @classmethod
     def from_env(cls) -> "MooncakeConfig":

--- a/torchspec/ray/placement_group.py
+++ b/torchspec/ray/placement_group.py
@@ -34,7 +34,6 @@ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from torchspec.ray.train_group import RayTrainGroup
 from torchspec.utils.logging import logger
 
-
 # Ray exposes a tiny "node:<ip>" resource on each node. Requiring a fractional
 # amount pins a bundle to that node without consuming a full logical resource.
 _NODE_RESOURCE_EPSILON = 0.001

--- a/torchspec/transfer/mooncake/store.py
+++ b/torchspec/transfer/mooncake/store.py
@@ -73,6 +73,7 @@ class MooncakeHiddenStateStore(ABC):
                 "Set mooncake.device_name to a specific RDMA device (e.g. 'mlx5_0')."
             )
 
+        self.config.apply_env_defaults()
         self._store = MooncakeDistributedStore()
         logger.info(
             "Connecting to Mooncake master at %s, metadata server at %s",


### PR DESCRIPTION
Current Mooncake version has a bug with TCP-only hosts causing a SEGFAULT error. Set MC_STORE_MEMCPY=0 until the https://github.com/kvcache-ai/Mooncake/issues/1986 is fixed.

Although this documentation provides a hint, we can enhance usability by setting this default environment variable directly within the code.

If a user overlooks the guidance provided in this documentation, it would be extremely difficult to pinpoint the root cause of the issue based solely on the error message.

```
(raylet) A worker died or was killed while executing a task by an unexpected system error. To troubleshoot the problem, check the logs for the dead worker. Lease ID: 0b00000043c351dfa676154eb6e2d2d83b12cc84d4b0dd6f7c95895706e201b2 Worker ID: e80b5521d830d80614c25bcf5227a307abb4372b9112056245654785 Node ID: 881e316ecdb052ae3a7b7405e2cab0cc775044e5492e1473e235f653 Worker IP address: 10.233.74.188 Worker port: 35501 Worker PID: 887276 Worker exit type: SYSTEM_ERROR Worker exit detail: Worker unexpectedly exits with a connection error code 2. End of file. Some common causes include: (1) the process was killed by the OOM killer due to high memory usage, (2) ray stop --force was called, or (3) the worker crashed unexpectedly due to SIGSEGV or another unexpected error.
[2026-05-18 03:12:01,209] loop.py:130 INFO Shutting down 1 inference engine(s)...
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/jovyan/code/TorchSpec/torchspec/train_entry.py", line 416, in <module>
    train_async_no_generation(args)
  File "/home/jovyan/code/TorchSpec/torchspec/train_entry.py", line 403, in train_async_no_generation
    run_training_loop(
  File "/home/jovyan/code/TorchSpec/torchspec/controller/loop.py", line 470, in run_training_loop
    return training_loop(
           ^^^^^^^^^^^^^^
  File "/home/jovyan/code/TorchSpec/torchspec/controller/loop.py", line 314, in training_loop
    train_results = ray.get(train_futures)
                    ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/code/TorchSpec/.venv/lib/python3.11/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/code/TorchSpec/.venv/lib/python3.11/site-packages/ray/_private/client_mode_hook.py", line 107, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/code/TorchSpec/.venv/lib/python3.11/site-packages/ray/_private/worker.py", line 2980, in get
    values, debugger_breakpoint = worker.get_objects(
                                  ^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/code/TorchSpec/.venv/lib/python3.11/site-packages/ray/_private/worker.py", line 1025, in get_objects
    raise value
ray.exceptions.ActorDiedError: The actor died unexpectedly before finishing this task.
        class_name: TrainerActor
        actor_id: 3b496743efbcb5868b136aba01000000
        pid: 887276
        namespace: 4b085ef6-2e8d-467e-b0b2-edf27331584d
        ip: 10.233.74.188
The actor is dead because its worker process has died. Worker exit type: SYSTEM_ERROR Worker exit detail: Worker unexpectedly exits with a connection error code 2. End of file. Some common causes include: (1) the process was killed by the OOM killer due to high memory usage, (2) ray stop --force was called, or (3) the worker crashed unexpectedly due to SIGSEGV or another unexpected error.
```