### PR TITLE
Fix Kimi generation prompt thinking block

### DIFF
--- a/tests/test_kimi_k25_parser.py
+++ b/tests/test_kimi_k25_parser.py
@@ -138,6 +138,14 @@ class TestKimiK25ParserBasic:
         assert len(input_ids) == len(loss_mask)
         assert loss_mask.sum() > 0
 
+    def test_generation_prompt_enters_thinking_block(self, mock_tokenizer, kimi_template):
+        parser = KimiK25Parser(mock_tokenizer, kimi_template)
+        conversation = [{"role": "user", "content": "Hello!"}]
+
+        formatted = parser.format(conversation, add_generation_prompt=True)
+
+        assert formatted.endswith("<|im_assistant|>assistant<|im_middle|><think>")
+
     def test_multi_turn_conversation(self, mock_tokenizer, kimi_template):
         parser = KimiK25Parser(mock_tokenizer, kimi_template)
         conversation = [

--- a/torchspec/data/parse.py
+++ b/torchspec/data/parse.py
@@ -478,7 +478,7 @@ class KimiK25Parser(Parser):
                 parts.append(f"{self.TOOL_HEADER}{content}{self.END_TOKEN}")
 
         if add_generation_prompt:
-            parts.append(self.ASSISTANT_HEADER)
+            parts.append(f"{self.ASSISTANT_HEADER}<think>")
 
         return "".join(parts)
 


### PR DESCRIPTION
## Summary
- make `KimiK25Parser.format(..., add_generation_prompt=True)` append `<think>` after the assistant header
- add a parser regression test for the generation prompt format

## Testing
- `.venv/bin/python -m pytest tests/test_kimi_k25_parser.py -q`
