### PR TITLE
Fix lint failures on main

### DIFF
--- a/torchspec/inference/engine/__init__.py
+++ b/torchspec/inference/engine/__init__.py
@@ -28,7 +28,7 @@ __all__ = [
 ]
 
 try:
-    from torchspec.inference.engine.hf_runner import HFRunner
+    from torchspec.inference.engine.hf_runner import HFRunner  # noqa: F401
 
     __all__.append("HFRunner")
 except ImportError as _e:

--- a/torchspec/inference/engine/sgl_engine_decode.py
+++ b/torchspec/inference/engine/sgl_engine_decode.py
@@ -211,9 +211,7 @@ class SglDecodeEngineMixin:
         top_k = getattr(self.args, "decode_top_k", -1)
         if top_k > 0:
             sampling_params["top_k"] = top_k
-        logger.debug(
-            f"SglEngine rank {self.rank}: decode sampling_params={sampling_params}"
-        )
+        logger.debug(f"SglEngine rank {self.rank}: decode sampling_params={sampling_params}")
 
         outputs: list[dict[str, Any] | None] = [None for _ in range(batch_size)]
         active_indices = list(range(batch_size))


### PR DESCRIPTION
Restore the Lint job to green so subsequent PRs land on a clean baseline. The optional HFRunner re-export was missing the F401 noqa that its SglEngine and VllmEngine siblings already carry, and a one-line debug log call had been committed in its expanded form.