### PR TITLE
feat: add D-PACE loss objective

### DIFF
--- a/docs/dflash/README.md
+++ b/docs/dflash/README.md
@@ -17,7 +17,7 @@ DFlash is a block-diffusion draft model for speculative decoding. Unlike Eagle3'
 
 - **Standalone model**: DFlash does not inherit Eagle3DraftModel — the interfaces are fundamentally different (dual-source KV vs input fusion, block-parallel vs autoregressive).
 - **FlexAttention for block-causal mask**: Reuses TorchSpec's `compile_friendly_flex_attention` and `compile_friendly_create_block_mask` singletons.
-- **CE loss**: Cross-entropy against ground truth tokens (not KL divergence against target distribution like Eagle3).
+- **CE loss**: Cross-entropy against ground truth tokens (not KL divergence against target distribution like Eagle3). The default objective uses DFlash's static exponential position decay; `dflash_loss_objective: dpace` enables dynamic D-PACE position weights.
 - **Config-based trainer dispatch**: `TrainerActor.init()` resolves the draft config and uses `isinstance(config, DFlashConfig)` to select the trainer.
 - **Shared target model**: Reuses `Eagle3TargetModel` with generalized N-layer support. The same hook-based mechanism works for both 3 and 5 layers.
 
@@ -247,6 +247,7 @@ Trained on 800K PerfectBlend for 3 epochs with WSD (Warmup-Stable-Decay) LR sche
 | `warmup_ratio` | 0.04 |
 | `weight_decay` | 0.01 |
 | `draft_accumulation_steps` | 2 |
+| `dflash_loss_objective` | decay |
 | `dflash_loss_decay_gamma` | 7.0 |
 | `dflash_num_anchors` | 512 |
 
@@ -260,6 +261,8 @@ Trained on 800K PerfectBlend for 3 epochs with WSD (Warmup-Stable-Decay) LR sche
 |-----------|---------|-------------|
 | `dflash_block_size` | 16 | Tokens predicted per block |
 | `dflash_num_anchors` | 512 | Anchor positions per sequence (biggest speed lever) |
+| `dflash_loss_objective` | decay | Position-weighting objective: `decay` for static exponential decay, `dpace` for dynamic D-PACE weights |
+| `dflash_dpace_alpha` | 0.5 | D-PACE smoothing factor used only when computing dynamic position weights |
 | `dflash_loss_decay_gamma` | 7.0 | Exponential decay rate for position-wise loss weighting |
 | `dflash_num_target_layers` | 5 | Number of target model layers to project from |
 

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -17,6 +17,7 @@ import torch
 from torchspec.models.dflash import (
     DFlashModel,
     _create_dflash_mask_mod,
+    _dpace_position_weights,
 )
 from torchspec.models.draft.dflash import (
     DFlashConfig,
@@ -53,7 +54,15 @@ def _make_config(
     )
 
 
-def _make_dflash_model(H=64, V=128, num_target_layers=2, block_size=4, num_anchors=4):
+def _make_dflash_model(
+    H=64,
+    V=128,
+    num_target_layers=2,
+    block_size=4,
+    num_anchors=4,
+    loss_objective="decay",
+    dpace_alpha=0.5,
+):
     """Helper to create a DFlashModel for testing."""
     config = _make_config(
         H=H,
@@ -70,6 +79,8 @@ def _make_dflash_model(H=64, V=128, num_target_layers=2, block_size=4, num_ancho
         draft_model=draft_model,
         block_size=block_size,
         num_anchors=num_anchors,
+        loss_objective=loss_objective,
+        dpace_alpha=dpace_alpha,
         loss_decay_gamma=7.0,
     )
 
@@ -515,6 +526,63 @@ class TestDFlashModelForward(unittest.TestCase):
         self.assertAlmostEqual(decay[0, 0, 2].item(), math.exp(-1.0 / 7.0), places=5)
         self.assertAlmostEqual(decay[0, 0, 15].item(), math.exp(-14.0 / 7.0), places=5)
 
+    def test_dpace_position_weights_match_formula(self):
+        confidences = torch.tensor([[[0.8, 0.5, 0.25]]], requires_grad=True)
+
+        weights = _dpace_position_weights(confidences, alpha=0.5)
+
+        expected = torch.tensor([[[1.996875, 1.096875, 0.421875]]])
+        torch.testing.assert_close(weights, expected)
+        self.assertFalse(weights.requires_grad)
+
+    def test_dpace_smoothing_keeps_later_weights_nonzero(self):
+        confidences = torch.tensor([[[0.0, 0.5, 0.25]]])
+
+        weights = _dpace_position_weights(confidences, alpha=0.5)
+
+        self.assertGreater(weights[0, 0, -1].item(), 0.0)
+
+    def test_invalid_dflash_loss_objective_raises(self):
+        with self.assertRaisesRegex(ValueError, "Unknown DFlash loss objective"):
+            _make_dflash_model(loss_objective="not-a-loss")
+
+    def test_invalid_dpace_alpha_raises(self):
+        with self.assertRaisesRegex(ValueError, "dflash_dpace_alpha"):
+            _make_dflash_model(loss_objective="dpace", dpace_alpha=1.5)
+
+    def test_dpace_loss_requires_grad(self):
+        """D-PACE should be differentiable through CE but not through dynamic weights."""
+        B, seq_len = 1, 32
+        input_ids = torch.randint(0, self.V, (B, seq_len))
+        hidden_states_list = [
+            torch.randn(B, seq_len, self.H) for _ in range(self.num_target_layers)
+        ]
+        loss_mask = torch.ones(B, seq_len)
+        lm_head_weight = torch.randn(self.V, self.H)
+        model = _make_dflash_model(
+            H=self.H,
+            V=self.V,
+            num_target_layers=self.num_target_layers,
+            block_size=4,
+            num_anchors=4,
+            loss_objective="dpace",
+        )
+
+        model.train()
+        loss, *_ = model(
+            input_ids=input_ids,
+            hidden_states_list=hidden_states_list,
+            loss_mask=loss_mask,
+            lm_head_weight=lm_head_weight,
+        )
+        loss.backward()
+
+        grad_found = any(
+            p.requires_grad and p.grad is not None and p.grad.abs().sum() > 0
+            for p in model.draft_model.parameters()
+        )
+        self.assertTrue(grad_found, "No gradient flowed to draft model parameters")
+
     def test_label_alignment_same_position(self):
         """Labels at positions anchor+0..anchor+block_size-1 (same-position prediction)."""
         device = torch.device("cpu")
@@ -926,6 +994,8 @@ class TestDFlashTrainingConfig(unittest.TestCase):
         config = TrainingConfig()
         self.assertEqual(config.dflash_block_size, 16)
         self.assertEqual(config.dflash_num_anchors, 512)
+        self.assertEqual(config.dflash_loss_objective, "decay")
+        self.assertEqual(config.dflash_dpace_alpha, 0.5)
         self.assertEqual(config.dflash_loss_decay_gamma, 7.0)
         self.assertEqual(config.dflash_num_target_layers, 5)
 
@@ -937,16 +1007,21 @@ class TestDFlashTrainingConfig(unittest.TestCase):
         schema = OmegaConf.structured(Config)
         self.assertEqual(schema.training.dflash_block_size, 16)
         self.assertEqual(schema.training.dflash_num_target_layers, 5)
+        self.assertEqual(schema.training.dflash_loss_objective, "decay")
 
         overrides = OmegaConf.from_dotlist(
             [
                 "training.dflash_block_size=8",
                 "training.dflash_num_target_layers=3",
+                "training.dflash_loss_objective=dpace",
+                "training.dflash_dpace_alpha=0.3",
             ]
         )
         merged = OmegaConf.merge(schema, overrides)
         self.assertEqual(merged.training.dflash_block_size, 8)
         self.assertEqual(merged.training.dflash_num_target_layers, 3)
+        self.assertEqual(merged.training.dflash_loss_objective, "dpace")
+        self.assertAlmostEqual(merged.training.dflash_dpace_alpha, 0.3)
 
 
 class TestDFlashTrainingQuality(unittest.TestCase):
@@ -1189,6 +1264,8 @@ class TestDFlashConfigYAML(unittest.TestCase):
         self.assertEqual(config.training.dflash_block_size, 16)
         self.assertEqual(config.training.dflash_num_anchors, 512)
         self.assertEqual(config.training.dflash_num_target_layers, 5)
+        self.assertEqual(config.training.dflash_loss_objective, "decay")
+        self.assertAlmostEqual(config.training.dflash_dpace_alpha, 0.5)
         self.assertAlmostEqual(config.training.dflash_loss_decay_gamma, 7.0)
         self.assertEqual(
             config.model.draft_model_config,

--- a/torchspec/config/train_config.py
+++ b/torchspec/config/train_config.py
@@ -148,7 +148,9 @@ class TrainingConfig:
 
     # DFlash-specific parameters (ignored for Eagle3 training)
     dflash_block_size: int = 16
+    dflash_dpace_alpha: float = 0.5
     dflash_loss_decay_gamma: float = 7.0
+    dflash_loss_objective: str = "decay"  # "decay" or "dpace"
     dflash_num_anchors: int = 512
     dflash_num_target_layers: int = 5
 

--- a/torchspec/models/dflash.py
+++ b/torchspec/models/dflash.py
@@ -35,6 +35,23 @@ import torch.nn.functional as F
 from torchspec.models.ops.flex_attention import compile_friendly_create_block_mask
 from torchspec.utils.logging import logger
 
+_VALID_DFLASH_LOSS_OBJECTIVES = {"decay", "dpace"}
+
+
+def _dpace_position_weights(confidences: torch.Tensor, alpha: float) -> torch.Tensor:
+    """Compute detached D-PACE weights from per-position draft confidences."""
+    if not 0.0 <= alpha <= 1.0:
+        raise ValueError(f"dflash_dpace_alpha must be in [0, 1], got {alpha}")
+
+    with torch.no_grad():
+        smoothed = (1.0 - alpha) * confidences.float() + alpha
+        prefix_products = torch.cumprod(smoothed, dim=-1)
+        weights = torch.flip(
+            torch.cumsum(torch.flip(prefix_products, dims=[-1]), dim=-1),
+            dims=[-1],
+        )
+        return weights.to(dtype=confidences.dtype)
+
 
 def _create_dflash_mask_mod(
     anchor_positions: torch.Tensor,
@@ -80,7 +97,7 @@ class DFlashModel(nn.Module):
       - Random anchor sampling with block_keep_mask
       - Block-causal attention mask via FlexAttention
       - Noise input construction (anchor + MASK)
-      - Cross-entropy loss with exponential decay weighting
+      - Cross-entropy loss with configurable position weighting
       - Per-position loss_mask application
     """
 
@@ -89,12 +106,25 @@ class DFlashModel(nn.Module):
         draft_model,
         block_size: int = 16,
         num_anchors: int = 512,
+        loss_objective: str = "decay",
+        dpace_alpha: float = 0.5,
         loss_decay_gamma: float = 7.0,
     ):
         super().__init__()
+        loss_objective = loss_objective.lower()
+        if loss_objective not in _VALID_DFLASH_LOSS_OBJECTIVES:
+            valid = ", ".join(sorted(_VALID_DFLASH_LOSS_OBJECTIVES))
+            raise ValueError(
+                f"Unknown DFlash loss objective {loss_objective!r}; expected one of {valid}"
+            )
+        if not 0.0 <= dpace_alpha <= 1.0:
+            raise ValueError(f"dflash_dpace_alpha must be in [0, 1], got {dpace_alpha}")
+
         self.draft_model = draft_model
         self.block_size = block_size
         self.num_anchors = num_anchors
+        self.loss_objective = loss_objective
+        self.dpace_alpha = dpace_alpha
         self.loss_decay_gamma = loss_decay_gamma
 
     def _sample_anchor_positions(
@@ -221,7 +251,7 @@ class DFlashModel(nn.Module):
         Matches SpecForge's OnlineDFlashModel.forward().
 
         Returns:
-            loss: scalar training loss (decay-weighted)
+            loss: scalar training loss (objective-weighted)
             accuracy: scalar accuracy (binary mask, no decay)
             loss_per_position: [block_size] mean loss at each within-block position
                 (index 0 is the anchor slot and always 0; indices 1..B-1 are the
@@ -316,24 +346,41 @@ class DFlashModel(nn.Module):
         )
         weight_mask = weight_mask * original_loss_mask_gathered
 
-        # Capture binary mask BEFORE applying decay weights. Accuracy measures
-        # "did we predict correctly?" uniformly across positions, while decay
+        # Capture binary mask BEFORE applying objective weights. Accuracy measures
+        # "did we predict correctly?" uniformly across positions, while weighting
         # only shapes gradient contribution. SpecForge uses no decay at all;
-        # our decay weighting is an addition to the training signal, not the metric.
+        # our objective weighting is an addition to the training signal, not the metric.
         binary_eval_mask = weight_mask.view(-1)
-
-        # Loss decay: exp(-(k-1)/γ) so k=1 (1st prediction) gets weight 1.0
-        if self.loss_decay_gamma is not None and self.loss_decay_gamma > 0:
-            k = torch.arange(self.block_size, device=device).view(1, 1, -1)
-            decay_weights = torch.exp(-(k - 1).clamp(min=0).float() / self.loss_decay_gamma)
-            weight_mask = weight_mask * decay_weights
 
         # 9. Cross entropy loss
         flat_logits = logits.view(-1, logits.size(-1))
         flat_targets = target_ids.view(-1)
-        flat_weights = weight_mask.view(-1)
-
         loss_per_token = F.cross_entropy(flat_logits, flat_targets, reduction="none")
+        loss_per_token_by_position = loss_per_token.view(bsz, n_blocks, self.block_size)
+
+        objective_weights = weight_mask
+        if (
+            self.loss_objective == "decay"
+            and self.loss_decay_gamma is not None
+            and self.loss_decay_gamma > 0
+        ):
+            # Loss decay: exp(-(k-1)/γ) so k=1 (1st prediction) gets weight 1.0
+            k = torch.arange(self.block_size, device=device).view(1, 1, -1)
+            decay_weights = torch.exp(-(k - 1).clamp(min=0).float() / self.loss_decay_gamma)
+            objective_weights = weight_mask * decay_weights
+        elif self.loss_objective == "dpace":
+            dpace_weights = torch.ones_like(weight_mask)
+            if self.block_size > 1:
+                with torch.no_grad():
+                    target_confidences = torch.exp(-loss_per_token_by_position[..., 1:].float())
+                    dpace_pred_weights = _dpace_position_weights(
+                        target_confidences,
+                        self.dpace_alpha,
+                    ).to(dtype=weight_mask.dtype)
+                dpace_weights[..., 1:] = dpace_pred_weights
+            objective_weights = weight_mask * dpace_weights
+
+        flat_weights = objective_weights.view(-1)
         valid_token_count = flat_weights.sum().clamp(min=1e-6)
         loss = (loss_per_token * flat_weights).sum() / valid_token_count
 

--- a/torchspec/training/dflash_trainer.py
+++ b/torchspec/training/dflash_trainer.py
@@ -49,6 +49,8 @@ class DFlashTrainer(Trainer):
         self.num_target_layers = getattr(args, "dflash_num_target_layers", 5)
         self.block_size = getattr(args, "dflash_block_size", 16)
         self.num_anchors = getattr(args, "dflash_num_anchors", 512)
+        self.loss_objective = getattr(args, "dflash_loss_objective", "decay")
+        self.dpace_alpha = getattr(args, "dflash_dpace_alpha", 0.5)
         self.loss_decay_gamma = getattr(args, "dflash_loss_decay_gamma", 7.0)
 
     def init_model(
@@ -123,6 +125,8 @@ class DFlashTrainer(Trainer):
             draft_model=draft_model,
             block_size=self.block_size,
             num_anchors=self.num_anchors,
+            loss_objective=self.loss_objective,
+            dpace_alpha=self.dpace_alpha,
             loss_decay_gamma=self.loss_decay_gamma,
         )
 


### PR DESCRIPTION
Add an opt-in dynamic position-weighting objective for DFlash draft
training. DFlash currently weights its per-position cross-entropy with a
static exponential decay (exp(-(k-1)/gamma)), which treats every block
the same regardless of how confident the draft model is at each step.
D-PACE instead derives per-position weights from the draft model's own
confidence in the target token, concentrating gradient on the positions
the draft is most likely to get right and accept.

Implementation follows the paper directly: per-position draft confidence
q_i = exp(-CE) on the target-selected token, asymmetric smoothing
q~ = (1 - alpha) * q + alpha (Eq. 7), per-position weights as the suffix
sums of the smoothed confidence prefix products (Eq. 8 / Algorithm 1),
and a detached weighted cross-entropy that keeps the raw -log q_j term
(Eq. 9). Weights are computed under no_grad so they shape gradient
magnitude without flowing gradient themselves.

Behavior is unchanged by default: dflash_loss_objective stays "decay",
and "dpace" is selected explicitly along with dflash_dpace_alpha (0.5).
Accuracy and per-position metrics continue to use the binary eval mask
so they remain comparable across objectives. This is the hard-label CE
variant only; the soft-label/KL (D-PAKL) variant is not implemented.

Intentional deviation from the paper: the loss is reduced as a weighted
mean (dividing by the sum of the position weights) rather than the
paper's unnormalized weighted sum (Eq. 9). The divisor is detached, so
per-position credit assignment is preserved and only the global loss
magnitude is rescaled; this matches the weighted-mean reduction the
existing decay baseline already uses, keeping LR/grad scale consistent
across objectives.

Idea and implementation derived from:
  D-PACE: Dynamic Position-Aware Cross-Entropy for Parallel Speculative
  Drafting. Tianyu Wu, Yu Yao, Zhenting Qi, Han Zheng, Zhuohan Wang,
  Haoran Ma, Lawrence Liao, Himabindu Lakkaraju, Ju Li, Yilun Du
  (Harvard & MIT, 2026). arXiv:2605.18810v1.
  https://github.com/Lucas-TY/D-PACE
