### PR TITLE
Support vLLM v0.22.1 + agent skill for future vLLM version bumps

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -27,12 +27,12 @@ jobs:
         env:
           BACKEND: vllm
           IMAGE_REPO: ${{ env.IMAGE_REPO }}
-          IMAGE_TAG: ${{ github.event.release.tag_name }}-vllm-v0.19.1
-          VLLM_VERSION: v0.19.1
+          IMAGE_TAG: ${{ github.event.release.tag_name }}-vllm-v0.22.1
+          VLLM_VERSION: v0.22.1
         run: just build
 
       - name: Push release image
         env:
           IMAGE_REPO: ${{ env.IMAGE_REPO }}
-          IMAGE_TAG: ${{ github.event.release.tag_name }}-vllm-v0.19.1
+          IMAGE_TAG: ${{ github.event.release.tag_name }}-vllm-v0.22.1
         run: docker push "${IMAGE_REPO}:${IMAGE_TAG}"

--- a/docker/justfile
+++ b/docker/justfile
@@ -1,6 +1,6 @@
 BACKEND := env("BACKEND", "sglang")
 SGLANG_VERSION := env("SGLANG_VERSION", "v0.5.8.post1")
-VLLM_VERSION := env("VLLM_VERSION", "v0.19.1")
+VLLM_VERSION := env("VLLM_VERSION", "v0.22.1")
 IMAGE_REPO := env("IMAGE_REPO", "ghcr.io/torchspec-project/torchspec")
 IMAGE_TAG := env("IMAGE_TAG", "")
 

--- a/docker/vllm/v0.22.1/Dockerfile
+++ b/docker/vllm/v0.22.1/Dockerfile
@@ -1,0 +1,22 @@
+FROM vllm/vllm-openai:v0.22.1
+
+WORKDIR /root/
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends nvtop rsync dnsutils && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY patches/vllm/v0.22.1/*.patch /tmp/patches/
+RUN cd /usr/local/lib/python3.12/dist-packages && \
+    for p in /tmp/patches/*.patch; do patch -p1 < "$p"; done && \
+    rm -rf /tmp/patches
+
+# NOTE: the base image ships its own CUDA-13-linked mooncake-transfer-engine
+# (0.3.10.post2), which satisfies torchspec's >=0.3.10.post1 floor. Do NOT
+# upgrade or reinstall mooncake from PyPI here: the generic wheel links
+# libcudart.so.12 (broken on this CUDA 13 image) and the cuda13 variant's
+# aarch64 wheel needs glibc >= 2.39 (this image is Ubuntu 22.04 / 2.35).
+COPY . /root/torchspec
+RUN cd /root/torchspec && pip install --no-cache-dir -e ".[fa]"
+
+WORKDIR /root/torchspec

--- a/patches/vllm/v0.22.1/vllm.patch
+++ b/patches/vllm/v0.22.1/vllm.patch
@@ -1,0 +1,42 @@
+TorchSpec patches for vllm v0.22.1
+
+1. Fix flash_attn rotary embedding import with FA4
+   vllm/model_executor/layers/rotary_embedding/common.py
+   flash-attn-4 provides the ``flash_attn`` module without
+   ``ops.triton.rotary``, so the unguarded import crashes at engine init
+   when FA4 is installed (e.g. via torchspec's ``.[fa]`` extra).
+
+Note: the remaining v0.19.1 patches are no longer needed on v0.22.1:
+- Quantized KV cache dtype fix: upstream in
+  vllm/model_executor/models/extract_hidden_states.py
+- VLM text_config fix (PR #38987): upstream in
+  vllm/transformers_utils/configs/extract_hidden_states.py
+- HiddenStatesCacheSpec + kv cache manager registration: upstream as
+  ``HiddenStateCacheSpec`` (vllm/v1/kv_cache_interface.py)
+- Qwen3NextModel EagleModelMixin hooks: upstream in
+  vllm/model_executor/models/qwen3_next.py
+- hybrid_kv_cache.patch (SupportsHMA connector check, heterogeneous page
+  sizes, per-layer CacheOnly slot mappings): superseded by the upstream
+  kv_offload+HMA series (PRs #36644, #36645, #37885, #38261, #38453,
+  #39401-#39403)
+
+Apply:
+  cd $VLLM_ROOT && git apply /path/to/vllm.patch
+
+--- a/vllm/model_executor/layers/rotary_embedding/common.py
++++ b/vllm/model_executor/layers/rotary_embedding/common.py
+@@ -136,9 +136,12 @@
+
+         self.apply_rotary_emb_flash_attn = None
+         if not current_platform.is_cpu() and find_spec("flash_attn") is not None:
+-            from flash_attn.ops.triton.rotary import apply_rotary
++            try:
++                from flash_attn.ops.triton.rotary import apply_rotary
+
+-            self.apply_rotary_emb_flash_attn = apply_rotary
++                self.apply_rotary_emb_flash_attn = apply_rotary
++            except (ImportError, ModuleNotFoundError):
++                pass
+
+     @staticmethod
+     def forward_static(

--- a/skills/vllm-version-bump/SKILL.md
+++ b/skills/vllm-version-bump/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: vllm-version-bump
+description: Use when updating TorchSpec's vLLM backend to a new vLLM release — adding docker/vllm/<version>/ and patches/vllm/<version>/, bumping docker/justfile or .github/workflows/docker-release.yml, or when a new vLLM breaks mooncake imports (libcudart), extract_hidden_states, or the Docker image build.
+---
+
+# vLLM Version Bump
+
+## Overview
+
+TorchSpec pins vLLM per version directory: `docker/vllm/<ver>/Dockerfile` builds on
+`vllm/vllm-openai:<ver>` and applies `patches/vllm/<ver>/*.patch` into the image's
+dist-packages; `docker/justfile` (`VLLM_VERSION` default) and
+`.github/workflows/docker-release.yml` (`VLLM_VERSION` + two `IMAGE_TAG`s) pin the
+release. A bump = new directory pair + pin updates + e2e training verification on
+BOTH surfaces (bare metal and the image). Input: target version `vX.Y.Z`.
+
+**Core principle: audit, don't copy.** Patches exist because fixes hadn't landed
+upstream yet. On every bump, most of them have. Carrying a patch forward without
+checking each hunk against the new version's installed source ships dead code at
+best and failed hunks at worst. (v0.19.1→v0.22.1: 466 patch lines shrank to one hunk.)
+
+## Phase 1 — Audit patches against the new vLLM
+
+1. Install the target into an env: `micromamba run -n torchspec uv pip install vllm==X.Y.Z`.
+2. For each hunk in the previous `patches/vllm/<prev>/*.patch`: grep the installed
+   source (`$ENV/lib/python3*/site-packages/vllm/...`). Has the fix landed upstream,
+   possibly under a different name? (Example: patched `HiddenStatesCacheSpec` landed
+   as `HiddenStateCacheSpec`.) Drop landed hunks; carry the rest.
+3. Regenerate carried hunks by diffing real installed source in a /tmp scratch dir
+   (copy file into `a/vllm/<path>/`, apply the edit into `b/vllm/<path>/`,
+   `diff -u a/... b/...`), never by hand-editing old hunks — context lines shift
+   between versions. Keep one `vllm.patch` per version (existing convention).
+4. Verify both apply methods against a copy of the tree: `patch -p1 --dry-run`
+   (what the Dockerfile runs) AND `git apply --check`. `python -m py_compile` the
+   patched file.
+5. Document dropped hunks and why in the patch header (see `patches/vllm/v0.22.1/vllm.patch`).
+
+Known long-lived hunk: the FA4 guard wrapping
+`from flash_attn.ops.triton.rotary import apply_rotary` in
+`vllm/model_executor/layers/rotary_embedding/common.py` — flash-attn-4 ships a
+`flash_attn` module without that path, and vLLM's bare import crashes engine init.
+Check each bump whether vLLM finally guarded it upstream.
+
+## Phase 2 — Create version files
+
+| File | Change |
+|---|---|
+| `docker/vllm/vX.Y.Z/Dockerfile` | Copy previous version's; bump `FROM` tag + patch dir |
+| `patches/vllm/vX.Y.Z/vllm.patch` | Output of Phase 1 |
+| `docker/justfile` | `VLLM_VERSION` default |
+| `.github/workflows/docker-release.yml` | `VLLM_VERSION` and both `IMAGE_TAG` values |
+
+Verify against the new base image BEFORE building:
+
+- Tag exists and arches: `https://hub.docker.com/v2/repositories/vllm/vllm-openai/tags?name=vX.Y`
+- Python version (the patch layer hardcodes `/usr/local/lib/python3.NN/dist-packages`):
+  check `ARG PYTHON_VERSION` in
+  `https://raw.githubusercontent.com/vllm-project/vllm/vX.Y.Z/docker/Dockerfile`.
+- **Never pip install/upgrade/uninstall mooncake inside the image.** The vllm-openai
+  image bundles its own CUDA-matched mooncake build that satisfies torchspec's floor;
+  PyPI wheels cannot replace it (the generic wheel links the wrong libcudart, and on
+  aarch64 ALL mooncake wheels need glibc ≥ 2.39 while the image is Ubuntu 22.04 /
+  glibc 2.35 — pip reports `versions: none`). Confirm the bundled build matches the
+  image's CUDA major:
+  `docker run --rm --entrypoint bash vllm/vllm-openai:vX.Y.Z -c 'ldd /usr/local/lib/python3*/dist-packages/mooncake/engine.so | grep cudart'`
+
+## Phase 3 — Bare-metal e2e
+
+1. Env: `./tools/build_conda.sh 1 vllm`.
+2. Check the mooncake/CUDA pairing — the canonical test is the linker, not release notes:
+   `ldd $ENV/lib/python3*/site-packages/mooncake/engine.so | grep -E "cudart|not found"`.
+   A `libcudart.so.NN => not found` means vLLM's torch stack moved CUDA major and the
+   default `mooncake-transfer-engine` wheel links the old runtime; swap:
+   `uv pip uninstall mooncake-transfer-engine && uv pip install mooncake-transfer-engine-cudaNN`.
+3. Run, capturing all output (key log lines arrive on both stdout and stderr):
+
+```bash
+export CUDA_VISIBLE_DEVICES=<the node's actual GPU ids>  # COUNT matters, not just ids:
+    # run.sh derives inference_num_gpus_per_node from it and defaults to 8 GPUs —
+    # on a 4-GPU node you MUST set 0,1,2,3 or the run is misconfigured
+export MC_STORE_MEMCPY=0                                 # mooncake-over-TCP bug (see README)
+./examples/qwen3-8b-single-node/run.sh configs/vllm_qwen3_8b.yaml \
+    training.num_train_steps=5 > /tmp/bump_e2e.log 2>&1
+```
+
+PASS requires ALL of: `initialized extract_hidden_states mode` in the log;
+`Training completed: 5 steps`; exit 0; final train loss < first train loss
+(this config starts ≈12 — compare `grep -oE "loss=[0-9.]+" /tmp/bump_e2e.log`
+first vs last train entries). Then probe the checkpoint:
+`python tools/convert_to_hf.py --input-dir outputs/.../iter_*/ --target-model-path Qwen/Qwen3-8B`.
+
+## Phase 4 — Docker e2e (replicates the release workflow's build)
+
+```bash
+cd docker && BACKEND=vllm VLLM_VERSION=vX.Y.Z IMAGE_REPO=local/torchspec \
+  IMAGE_TAG=test-vllm-vX.Y.Z just build
+
+# Sanity — mooncake import needs --gpus all even without training (libcuda.so.1):
+docker run --rm --gpus all --entrypoint python3 local/torchspec:test-vllm-vX.Y.Z -c \
+  "import vllm, torchspec, flash_attn; from mooncake.store import MooncakeDistributedStore; print('ok')"
+
+# e2e — the ONLY place the FA4 patch executes (flash-attn-4 is installed here, not bare metal):
+docker run --rm --gpus all --network=host --shm-size=16g --entrypoint bash \
+  -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+  -e MC_STORE_MEMCPY=0 -e CUDA_VISIBLE_DEVICES=<same ids as Phase 3> \
+  local/torchspec:test-vllm-vX.Y.Z \
+  examples/qwen3-8b-single-node/run.sh configs/vllm_qwen3_8b.yaml training.num_train_steps=5
+```
+
+`--entrypoint bash` is required (base entrypoint is the vLLM API server). Same PASS
+criteria as Phase 3.
+
+## Debugging table
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ImportError: libcudart.so.NN` from `mooncake.store` | vLLM moved CUDA major; mooncake wheel links the old runtime (torch no longer preloads it) | Bare metal: swap to `mooncake-transfer-engine-cudaNN`. Image: use the bundled mooncake — never reinstall |
+| `Mooncake master gRPC unreachable ... Connection refused` | Master died ~2s after start with exit 0 — usually a fixed-port bind failure (e.g. another master's metrics port) | Run the exact master command manually and read stderr; every port it binds must be free |
+| pip `versions: none` for mooncake during image build | aarch64 mooncake wheels need glibc ≥ 2.39; image is Ubuntu 22.04 (2.35) | Don't install mooncake in the image |
+| Patch layer: `Hunk #N FAILED` | Upstream code shifted | Regenerate the hunk per Phase 1 |
+| `ModuleNotFoundError: flash_attn.ops.triton.rotary` at engine init | FA4 guard hunk missing or not applied | Phase 1 known hunk |
+| Warning: `Model runner v2 does not yet support ... extract_hidden_states; using the v1 model runner` | Upstream fallback | OK while v1 runner exists; if a release removes it, STOP — extract_hidden_states needs vLLM-side work first |
+| Training hangs with `Sample pool full, pausing generation` only | Backpressure working; training side stalled for another reason | Check trainer actor logs, not inference |
+
+## Red flags — you are about to ship a broken bump
+
+- Copying `patches/` forward without auditing each hunk against the new installed source
+- Adding any mooncake pip operation to the vllm Dockerfile
+- Declaring PASS from build + import checks alone — a 5-step training run must complete on BOTH surfaces
+- Skipping the Docker e2e because bare metal passed — the FA4 patch path only executes in the image

--- a/torchspec/transfer/mooncake/utils.py
+++ b/torchspec/transfer/mooncake/utils.py
@@ -101,6 +101,8 @@ class MooncakeMaster(RayActor):
         if not os.path.exists(mooncake_bin):
             raise FileNotFoundError(f"mooncake_master binary not found at {mooncake_bin}")
 
+        # Pick a free port for metrics / admin server
+        metrics_port = self.find_free_port(start_port=random.randint(9100, 10100))
         cmd = [
             mooncake_bin,
             f"--port={port}",
@@ -108,6 +110,7 @@ class MooncakeMaster(RayActor):
             f"--http_metadata_server_host={http_host}",
             "--enable_http_metadata_server=true",
             f"--default_kv_lease_ttl={int(kv_lease_ttl_s * 1000)}",
+            f"--metrics_port={metrics_port}",
         ]
 
         logger.info(f"Starting mooncake master on port {port}")


### PR DESCRIPTION
## Summary

Bumps the vLLM Docker release from v0.19.1 to v0.22.1, fixes a latent mooncake master port-collision bug found during verification, and adds an agent skill that codifies the bump workflow for future versions.

### 1. vLLM v0.22.1 bump
- **`docker/vllm/v0.22.1/Dockerfile`** — based on `vllm/vllm-openai:v0.22.1` (multi-arch amd64+arm64). The base image bundles its own CUDA-13-linked `mooncake-transfer-engine` (0.3.10.post2) satisfying torchspec's `>=0.3.10.post1` floor; the Dockerfile deliberately does **not** touch mooncake — the generic PyPI wheel links `libcudart.so.12` (broken on this CUDA 13 image) and on aarch64 all mooncake wheels need glibc ≥ 2.39 vs the image's Ubuntu 22.04 (2.35).
- **`patches/vllm/v0.22.1/vllm.patch`** — audited every v0.19.1 hunk against the installed 0.22.1 source; only the FA4 guard around `flash_attn.ops.triton.rotary` survives (466 lines → 1 hunk). `HiddenStatesCacheSpec` (landed as `HiddenStateCacheSpec`), Qwen3Next Eagle hooks, quantized-KV fix, VLM `text_config` fix, and the entire hybrid-KV-cache patch all landed upstream. The patch header documents what was dropped and why.
- **`docker/justfile` / `.github/workflows/docker-release.yml`** — pin v0.22.1.

### 2. Mooncake master fix (`torchspec/transfer/mooncake/utils.py`)
The master's metrics/admin server binds a fixed port (9003) and the master exits (code 0, ~2s after start — racing past the liveness check) when it can't bind, e.g. when another mooncake master runs on the same host. The launcher now allocates the metrics port via `find_free_port`, matching the existing RPC/metadata port handling. Independent of the vLLM bump but required to run on shared hosts.

### 3. Agent skill (`skills/vllm-version-bump/SKILL.md`)
Runbook for future bumps: per-hunk patch audit against the new installed source (audit, don't copy), version-file creation with base-image verification, and 5-step training e2e on **both** surfaces — bare metal and the image (the FA4 patch path only executes in the image, where flash-attn-4 is installed). Includes a symptom→cause→fix table for every failure mode hit during this bump.

## Verification (GB200 node, 4 GPUs: 2× vLLM TP2 inference + 2× FSDP training)

- **Bare metal**: 20-step run (loss 12.18 → ~5.5, end eval executed) and 5-step run, exit 0, `extract_hidden_states` mode initialized with `layers=[2, 18, 33, 36]`; FSDP checkpoint converted via `tools/convert_to_hf.py`. Note: bare-metal envs on the vLLM 0.22 (CUDA 13) stack need `mooncake-transfer-engine-cuda13` in place of the default cu12-linked package.
- **Docker**: `BACKEND=vllm just build` (exactly what the release workflow runs), import sanity under the nvidia runtime, then an in-container 5-step run — losses match bare metal to 3 decimals (same seed). Verified the bundled mooncake is untouched (sha256-identical `engine.so`/`store.so` vs the pristine base image).

## Notes for reviewers

- vLLM 0.22.1 logs `Model runner v2 does not yet support speculative method 'extract_hidden_states'; using the v1 model runner instead` — fine today, but extract_hidden_states needs upstream work before vLLM removes the v1 runner.
- The FA4 rotary guard is a small, uncontroversial fix that could be upstreamed to vLLM, which would empty this patch entirely.
- Bare-metal installs via `build_conda.sh 1 vllm` still pull the cu12-linked mooncake from pyproject — users on the 0.22 stack must swap manually (documented in the skill). Making the swap automatic in `build_conda.sh` is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)