### PR TITLE
feat(dflash): add DSpark training as a DeepSpec-faithful extension of DFlash

### DIFF
--- a/configs/sglang_qwen3_8b_dspark.yaml
+++ b/configs/sglang_qwen3_8b_dspark.yaml
@@ -1,0 +1,94 @@
+# DSpark training config for Qwen3-8B target model
+#
+# Identical to configs/sglang_qwen3_8b_dflash.yaml except for the DSpark deltas, so the
+# two form a clean A/B (same data, schedule, block/anchor/target-layer setup, seed):
+#   - draft_model_config -> dspark_draft_config.json (adds markov_rank=256,
+#     markov_head_type=vanilla, enable_confidence_head=true)
+#   - training.dflash_loss_objective: dspark  (CE + TV/L1 + confidence BCE)
+#   - training.dflash_dspark_{ce,l1,confidence}_alpha
+#   - inference.store_last_hidden_states: true  (required: the dspark objective builds
+#     target distributions from the target's last hidden state)
+#
+# GPU allocation (8x GPU): 4 inference (SGLang, tp=1, duplicate) + 4 training (FSDP).
+#
+# Usage:
+#   python -m torchspec.train_entry --config configs/sglang_qwen3_8b_dspark.yaml \
+#     dataset.train_data_path=/path/to/data.jsonl output_dir=./outputs/dspark
+
+model:
+  target_model_path: Qwen/Qwen3-8B
+  trust_remote_code: true
+  draft_model_config: torchspec/config/dspark_draft_config.json
+
+dataset:
+  train_data_path: ../examples/data/sample_conversations.jsonl
+  eval_data_path: null
+  eval_interval: 100
+  chat_template: qwen
+  prompt_key: conversations
+  min_loss_tokens: 32
+
+training:
+  attention_backend: flex_attention
+  micro_batch_size: 1
+  draft_accumulation_steps: 2
+  learning_rate: 6e-4
+  min_lr: 6e-5
+  weight_decay: 0.0
+  max_concurrent_batches: 1
+  max_grad_norm: 1.0
+  max_seq_length: 2048
+  num_epochs: 3
+  seed: 42
+  training_num_gpus_per_node: 4
+  training_num_nodes: 1
+  ttt_length: 7
+  fsdp_strategy: FULL_SHARD
+  fsdp_reduce_dtype: bfloat16
+  prefetch_depth: 8
+  save_interval: 1000
+  save_per_epoch: true
+  max_checkpoints: 2
+  warmup_ratio: 0.04
+
+  # DFlash/DSpark-specific parameters (block/anchor/target-layer identical to baseline)
+  dflash_block_size: 7
+  dflash_num_anchors: 512
+  dflash_loss_decay_gamma: 4.0
+  dflash_num_target_layers: 5
+
+  # DSpark objective: CE + TV/L1 distribution matching + confidence-head BCE
+  dflash_loss_objective: dspark
+  dflash_dspark_ce_alpha: 0.1
+  dflash_dspark_l1_alpha: 0.9
+  dflash_dspark_confidence_alpha: 1.0
+
+inference:
+  inference_engine_type: sgl
+  store_last_hidden_states: true  # required for the dspark objective
+  inference_num_gpus: 4
+  inference_num_gpus_per_engine: 1
+  inference_num_gpus_per_node: 4
+  max_sample_pool_size: 64
+  inference_buffer_threshold: 32
+  inference_batch_size: 8
+  sglang:
+    tp_size: 1
+    mem_fraction_static: 0.7
+
+mooncake:
+  master_server_address: null
+  metadata_server: null
+  protocol: tcp
+  global_segment_size: 16GB
+  local_buffer_size: 4GB
+  enable_hard_pin: true
+
+output_dir: ./outputs/qwen3-8b-dspark
+cache_dir: ./cache/qwen3-8b-dspark
+model_download_dir: null
+
+debug:
+  save_debug_train_data: null
+  debug_train_only: false
+  debug_inference_only: false

--- a/tests/test_dspark.py
+++ b/tests/test_dspark.py
@@ -1,0 +1,263 @@
+"""Unit tests for the DSpark training objective.
+
+DSpark is the existing DFlash drafter run with ``loss_objective="dspark"`` plus the
+Markov / confidence heads. These tests pin the DSpark wiring (so a refactor can't
+silently break the objective) and check numerical faithfulness to DeepSeek's
+DeepSpec reference loss.
+
+The DeepSpec loss math is vendored verbatim below (not imported) so the test suite
+has no dependency on the ``deepspec`` package -- see the permalink on
+``_deepspec_reference_components``.
+
+CPU-only and tiny by design (block_mask falls back to dense SDPA off-CUDA).
+"""
+
+import torch
+import torch.nn.functional as F
+
+from torchspec.models.dflash import DFlashModel
+from torchspec.models.draft.dflash import (
+    DFlashAcceptRatePredictor,
+    DFlashConfig,
+    DFlashDraftModel,
+    DFlashMarkovHead,
+)
+
+CE_A, L1_A, CF_A, GAMMA = 0.1, 0.9, 1.0, 4.0
+
+
+# --------------------------------------------------------------------------------------
+# Vendored DeepSpec reference loss math (not imported).
+# Copied/adapted verbatim from DeepSeek DeepSpec @ dd854392fadf053cfddcbc4dc0e6e32de46d1bd0:
+#   https://github.com/deepseek-ai/DeepSpec/blob/dd854392fadf053cfddcbc4dc0e6e32de46d1bd0/deepspec/modeling/dspark/loss.py
+# (single-process / world_size==1 form: loss_weight_mask = eval_mask * exp(-k/gamma);
+#  per-term numerator/denominator with den + 1e-6; CE + TV-L1 + confidence BCE against the
+#  accept-rate target 1 - 0.5*L1; softmax in fp32).
+# --------------------------------------------------------------------------------------
+def _deepspec_reference_components(
+    draft_logits, target_logits, target_ids, eval_mask, decay, confidence_pred
+):
+    vocab = draft_logits.shape[-1]
+    loss_weight_mask = eval_mask.to(torch.float32) * decay  # [B, N, bs]
+    w = loss_weight_mask.reshape(-1)
+    den = w.sum() + 1e-6
+
+    ce_pt = F.cross_entropy(
+        draft_logits.reshape(-1, vocab), target_ids.reshape(-1), reduction="none"
+    )
+    ce = (ce_pt * w).sum() / den
+
+    draft_probs = torch.softmax(draft_logits.reshape(-1, vocab).float(), dim=-1)
+    target_probs = torch.softmax(target_logits.reshape(-1, vocab).float(), dim=-1)
+    l1_pt = (draft_probs - target_probs).abs().sum(dim=-1)
+    l1 = (l1_pt * w).sum() / den
+
+    accept = (1.0 - 0.5 * l1_pt).clamp(0.0, 1.0)
+    bce = F.binary_cross_entropy_with_logits(
+        confidence_pred.reshape(-1).float(), accept, reduction="none"
+    )
+    conf = (bce * w).sum() / den
+    return ce, l1, conf
+
+
+# --------------------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------------------
+def _make_config(
+    H=64, V=128, markov_rank=16, enable_confidence_head=True, confidence_head_with_markov=True
+):
+    return DFlashConfig(
+        hidden_size=H,
+        intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        vocab_size=V,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=512,
+        rope_theta=10000.0,
+        num_target_layers=2,
+        target_hidden_size=H,
+        target_num_hidden_layers=12,
+        mask_token_id=V - 1,
+        markov_rank=markov_rank,
+        markov_head_type="vanilla",
+        enable_confidence_head=enable_confidence_head,
+        confidence_head_with_markov=confidence_head_with_markov,
+    )
+
+
+def _make_model(block_size=4, num_anchors=8, **cfg_kw):
+    config = _make_config(**cfg_kw)
+    draft = DFlashDraftModel(config).to(dtype=torch.float32)
+    draft.freeze_embedding()
+    return DFlashModel(
+        draft_model=draft,
+        block_size=block_size,
+        num_anchors=num_anchors,
+        loss_objective="dspark",
+        loss_decay_gamma=GAMMA,
+        dspark_ce_alpha=CE_A,
+        dspark_l1_alpha=L1_A,
+        dspark_confidence_alpha=CF_A,
+    )
+
+
+def _make_batch(B=2, S=32, H=64, V=128, num_target_layers=2, all_masked=False, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    input_ids = torch.randint(0, V, (B, S), generator=g)
+    hidden_states_list = [torch.randn(B, S, H, generator=g) for _ in range(num_target_layers)]
+    loss_mask = torch.zeros(B, S) if all_masked else torch.ones(B, S)
+    if not all_masked:
+        loss_mask[:, :2] = 0  # prompt prefix
+    lm_head_weight = torch.randn(V, H, generator=g)
+    last_hidden = torch.randn(B, S, H, generator=g)
+    return dict(
+        input_ids=input_ids,
+        hidden_states_list=hidden_states_list,
+        loss_mask=loss_mask,
+        lm_head_weight=lm_head_weight,
+        target_last_hidden_states=last_hidden,
+    )
+
+
+# --------------------------------------------------------------------------------------
+# Self-consistency (no DeepSpec dependency)
+# --------------------------------------------------------------------------------------
+def test_forward_returns_five_tuple_and_components():
+    m = _make_model()
+    out = m(**_make_batch())
+    assert len(out) == 5
+    loss, acc, lpp, app, cpp = out
+    assert torch.isfinite(loss)
+    assert set(m._dspark_components) == {"dspark_ce", "dspark_l1", "dspark_conf"}
+    for v in m._dspark_components.values():
+        assert torch.isfinite(v).all() and not v.requires_grad
+    assert lpp.shape[0] == m.block_size
+
+
+def test_loss_is_alpha_weighted_sum_of_components():
+    # world_size==1 -> backward loss equals the alpha-weighted sum of the logged
+    # (local-mean) components, so the components faithfully decompose the objective.
+    m = _make_model()
+    loss, *_ = m(**_make_batch(seed=1))
+    c = m._dspark_components
+    recomputed = CE_A * c["dspark_ce"] + L1_A * c["dspark_l1"] + CF_A * c["dspark_conf"]
+    torch.testing.assert_close(loss, recomputed, rtol=1e-5, atol=1e-4)
+
+
+def test_all_masked_is_zero():
+    m = _make_model()
+    loss, *_ = m(**_make_batch(all_masked=True))
+    assert abs(loss.item()) < 1e-4
+
+
+def test_next_token_supervises_all_block_slots():
+    # DSpark uses the next-token convention: slot 0 (seeded by the anchor token) is
+    # supervised too, unlike DFlash infill where slot 0 is the masked anchor. With a
+    # fully supervised sequence every within-block position should accumulate count.
+    m = _make_model(block_size=4, num_anchors=8)
+    b = _make_batch(B=2, S=40)
+    b["loss_mask"] = torch.ones(2, 40)
+    _, _, _, _, cpp = m(**b)
+    assert cpp.shape[0] == 4
+    assert (cpp > 0).all(), f"some slot unsupervised: {cpp.tolist()}"
+
+
+def test_grad_flow_and_frozen_embedding():
+    m = _make_model()
+    loss, *_ = m(**_make_batch(seed=2))
+    loss.backward()
+    d = m.draft_model
+    assert d.markov_head.markov_w2.weight.grad is not None
+    assert d.markov_head.markov_w2.weight.grad.abs().sum() > 0
+    assert d.confidence_head.proj.weight.grad is not None
+    assert d.confidence_head.proj.weight.grad.abs().sum() > 0
+    assert d.context_proj.weight.grad is not None
+    assert d.embed_tokens.weight.grad is None  # frozen
+
+
+# --------------------------------------------------------------------------------------
+# Head math
+# --------------------------------------------------------------------------------------
+def test_vanilla_markov_is_low_rank_bigram_bias():
+    torch.manual_seed(0)
+    mk = DFlashMarkovHead(vocab_size=50, markov_rank=8)
+    base = torch.randn(2, 3, 4, 50)
+    prev = torch.randint(0, 50, (2, 3, 4))
+    out = mk.apply_block_logits(base, prev)
+    expected = base + mk.markov_w2(mk.markov_w1(prev))
+    torch.testing.assert_close(out, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_confidence_head_is_linear():
+    torch.manual_seed(0)
+    head = DFlashAcceptRatePredictor(20)
+    feats = torch.randn(2, 3, 4, 20)
+    out = head(feats)
+    torch.testing.assert_close(out, head.proj(feats).squeeze(-1), rtol=1e-5, atol=1e-6)
+    assert out.shape == (2, 3, 4)
+
+
+# --------------------------------------------------------------------------------------
+# Numerical faithfulness vs the vendored DeepSpec reference
+# --------------------------------------------------------------------------------------
+def test_dspark_loss_components_match_deepspec_reference():
+    """DFlashModel._dspark_loss components match the vendored DeepSpec formula.
+
+    Fully-supervised eval mask (all rows valid) so the valid-row optimization in
+    _dspark_loss reduces to the dense reference computation.
+    """
+    torch.manual_seed(0)
+    B, N, bs, V, H, S = 2, 3, 4, 128, 64, 40
+    m = _make_model(block_size=bs, num_anchors=8)
+
+    flat_logits = torch.randn(B * N * bs, V)
+    target_ids = torch.randint(0, V, (B, N, bs))
+    label_indices = torch.randint(1, S, (B, N, bs))
+    target_last_hidden = torch.randn(B, S, H)
+    lm_head_weight = torch.randn(V, H)
+    draft_hidden = torch.randn(B * N * bs, H)
+    anchor_tok = torch.randint(0, V, (B, N, 1))
+    prev_token_ids = torch.cat([anchor_tok, target_ids[:, :, :-1]], dim=-1)
+
+    eval_mask = torch.ones(B, N, bs)  # fully supervised
+    k = torch.arange(bs).view(1, 1, -1)
+    decay = torch.exp(-k.float() / GAMMA)
+
+    loss_per_token = F.cross_entropy(flat_logits, target_ids.reshape(-1), reduction="none")
+
+    m._dspark_loss(
+        flat_logits=flat_logits,
+        loss_per_token=loss_per_token,
+        draft_hidden=draft_hidden,
+        weight_mask=eval_mask,
+        decay_weights=decay,
+        label_indices=label_indices,
+        target_last_hidden_states=target_last_hidden,
+        lm_head_weight=lm_head_weight,
+        bsz=B,
+        n_blocks=N,
+        prev_token_ids=prev_token_ids,
+    )
+    ours = m._dspark_components
+
+    # Re-derive the same target logits + confidence the way _dspark_loss does, then
+    # apply the vendored DeepSpec formula.
+    tgt_idx = (label_indices - 1).clamp(min=0, max=S - 1)
+    gather_idx = tgt_idx.reshape(B, N * bs, 1).expand(B, N * bs, H)
+    aligned = torch.gather(target_last_hidden, 1, gather_idx).reshape(B, N, bs, H)
+    target_logits = F.linear(aligned, lm_head_weight)
+    draft_logits_4d = flat_logits.reshape(B, N, bs, V)
+
+    prev_emb = m.draft_model.markov_head.get_prev_embeddings(prev_token_ids)
+    conf_feats = torch.cat([draft_hidden.reshape(B, N, bs, H), prev_emb], dim=-1)
+    confidence_pred = m.draft_model.confidence_head(conf_feats)
+
+    ref_ce, ref_l1, ref_conf = _deepspec_reference_components(
+        draft_logits_4d, target_logits, target_ids, eval_mask, decay, confidence_pred
+    )
+
+    torch.testing.assert_close(ours["dspark_ce"], ref_ce, rtol=1e-4, atol=1e-5)
+    torch.testing.assert_close(ours["dspark_l1"], ref_l1, rtol=1e-4, atol=1e-5)
+    torch.testing.assert_close(ours["dspark_conf"], ref_conf, rtol=1e-4, atol=1e-5)

--- a/tools/convert_to_hf.py
+++ b/tools/convert_to_hf.py
@@ -484,6 +484,28 @@ def _convert_fsdp_to_hf(
     config = AutoDraftModelConfig.from_file(config_path)
     hf_model = AutoEagle3DraftModel.from_config(config)
 
+    # DSpark heads (Markov / confidence) live under draft_model.* and are extracted above.
+    # If the checkpoint carries them but the draft config does not enable them, the model
+    # built from config lacks those modules and load_state_dict(strict=False) would drop
+    # them silently. Fail loudly so the trained heads actually reach the serving engine.
+    if (
+        any(k.startswith("markov_head.") for k in model_state)
+        and int(getattr(config, "markov_rank", 0) or 0) <= 0
+    ):
+        raise ValueError(
+            "Checkpoint contains Markov head weights (markov_head.*) but the draft config "
+            "has markov_rank=0; the head would be silently dropped. Set markov_rank (and "
+            "markov_head_type) in the draft config to match the trained model."
+        )
+    if any(k.startswith("confidence_head.") for k in model_state) and not getattr(
+        config, "enable_confidence_head", False
+    ):
+        raise ValueError(
+            "Checkpoint contains confidence head weights (confidence_head.*) but the draft "
+            "config has enable_confidence_head=false; the head would be silently dropped. "
+            "Set enable_confidence_head=true in the draft config to match the trained model."
+        )
+
     ckpt_dtype = Counter(v.dtype for v in model_state.values()).most_common(1)[0][0]
     final_dtype = output_dtype or ckpt_dtype
     logger.info("Checkpoint dtype: %s, output dtype: %s", ckpt_dtype, final_dtype)

--- a/torchspec/config/dspark_draft_config.json
+++ b/torchspec/config/dspark_draft_config.json
@@ -1,0 +1,23 @@
+{
+    "architectures": ["DFlashDraftModel"],
+    "model_type": "dflash",
+    "hidden_size": 4096,
+    "intermediate_size": 12288,
+    "num_hidden_layers": 5,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 8,
+    "vocab_size": 151936,
+    "rms_norm_eps": 1e-6,
+    "max_position_embeddings": 40960,
+    "rope_theta": 1000000.0,
+    "num_target_layers": 5,
+    "target_hidden_size": 4096,
+    "target_num_hidden_layers": 36,
+    "target_layer_ids": [1, 9, 17, 25, 33],
+    "mask_token_id": 151669,
+    "tie_word_embeddings": false,
+    "markov_rank": 256,
+    "markov_head_type": "vanilla",
+    "enable_confidence_head": true,
+    "confidence_head_with_markov": true
+}

--- a/torchspec/config/train_config.py
+++ b/torchspec/config/train_config.py
@@ -150,9 +150,16 @@ class TrainingConfig:
     dflash_block_size: int = 16
     dflash_dpace_alpha: float = 0.5
     dflash_loss_decay_gamma: float = 7.0
-    dflash_loss_objective: str = "decay"  # "decay" or "dpace"
+    dflash_loss_objective: str = "decay"  # "decay", "dpace", or "dspark"
     dflash_num_anchors: int = 512
     dflash_num_target_layers: int = 5
+    # DSpark objective loss weights (used only when dflash_loss_objective == "dspark"):
+    # CE + TV/L1 distribution matching + optional confidence-head BCE. The Markov head and
+    # confidence head themselves are architecture knobs on the draft model config
+    # (markov_rank, enable_confidence_head), not training knobs.
+    dflash_dspark_ce_alpha: float = 0.1
+    dflash_dspark_l1_alpha: float = 0.9
+    dflash_dspark_confidence_alpha: float = 1.0
 
 
 @dataclass

--- a/torchspec/models/dflash.py
+++ b/torchspec/models/dflash.py
@@ -26,16 +26,17 @@ and cross-entropy loss with exponential decay weighting.
 Matches SpecForge's OnlineDFlashModel (specforge/core/dflash.py).
 """
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 
 from torchspec.models.ops.flex_attention import compile_friendly_create_block_mask
 from torchspec.utils.logging import logger
 
-_VALID_DFLASH_LOSS_OBJECTIVES = {"decay", "dpace"}
+_VALID_DFLASH_LOSS_OBJECTIVES = {"decay", "dpace", "dspark"}
 
 
 def _dpace_position_weights(confidences: torch.Tensor, alpha: float) -> torch.Tensor:
@@ -109,6 +110,9 @@ class DFlashModel(nn.Module):
         loss_objective: str = "decay",
         dpace_alpha: float = 0.5,
         loss_decay_gamma: float = 7.0,
+        dspark_ce_alpha: float = 0.1,
+        dspark_l1_alpha: float = 0.9,
+        dspark_confidence_alpha: float = 1.0,
     ):
         super().__init__()
         loss_objective = loss_objective.lower()
@@ -126,6 +130,11 @@ class DFlashModel(nn.Module):
         self.loss_objective = loss_objective
         self.dpace_alpha = dpace_alpha
         self.loss_decay_gamma = loss_decay_gamma
+        self.dspark_ce_alpha = dspark_ce_alpha
+        self.dspark_l1_alpha = dspark_l1_alpha
+        self.dspark_confidence_alpha = dspark_confidence_alpha
+        # Detached DSpark component losses from the last forward (best-effort logging).
+        self._dspark_components: dict = {}
 
     def _sample_anchor_positions(
         self,
@@ -191,6 +200,52 @@ class DFlashModel(nn.Module):
 
         return anchors, keep_mask
 
+    def _sample_anchor_positions_dspark(
+        self,
+        seq_len: int,
+        loss_mask: torch.Tensor,
+        device: torch.device,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """DeepSpec-faithful anchor sampling for the dspark objective.
+
+        Candidates require both the anchor token and its first target token to be valid
+        (loss_mask[i] and loss_mask[i+1]), over positions [0, seq_len-2]. This avoids
+        wasting anchor slots on blocks whose first prediction is masked — which the
+        eval-mask cumprod would otherwise void entirely. Mirrors DeepSpec
+        common.py:sample_anchor_positions. The DFlash (decay/dpace) path keeps the
+        original anchor-only sampler above.
+        """
+        bsz = loss_mask.shape[0]
+        max_n = self.num_anchors
+        num_candidates = max(seq_len - 1, 0)
+        if num_candidates == 0:
+            anchors = torch.zeros(bsz, max_n, dtype=torch.long, device=device)
+            keep = torch.zeros(bsz, max_n, dtype=torch.bool, device=device)
+            return anchors, keep
+
+        anchor_valid = loss_mask[:, :num_candidates] > 0.5
+        first_target_valid = loss_mask[:, 1 : num_candidates + 1] > 0.5
+        valid = anchor_valid & first_target_valid
+        valid_counts = valid.sum(dim=1)
+
+        indices = torch.arange(num_candidates, device=device).unsqueeze(0).expand(bsz, -1)
+        masked_indices = torch.where(valid, indices, torch.full_like(indices, seq_len + 1))
+        random_vals = torch.rand(bsz, num_candidates, device=device)
+        random_vals = torch.where(valid, random_vals, torch.full_like(random_vals, 2.0))
+        _, sorted_idx = random_vals.sort(dim=1)
+        gathered = torch.gather(masked_indices, 1, sorted_idx)
+        if num_candidates < max_n:
+            pad = torch.full(
+                (bsz, max_n - num_candidates), seq_len + 1, dtype=gathered.dtype, device=device
+            )
+            gathered = torch.cat([gathered, pad], dim=1)
+        anchors = gathered[:, :max_n].sort(dim=1).values
+        keep = torch.arange(max_n, device=device).unsqueeze(0) < valid_counts.unsqueeze(1).clamp(
+            max=max_n
+        )
+        anchors = torch.where(keep, anchors, torch.zeros_like(anchors))
+        return anchors, keep
+
     def _create_position_ids(
         self, anchor_positions: torch.Tensor, seq_len: int
     ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -245,6 +300,7 @@ class DFlashModel(nn.Module):
         hidden_states_list: List[torch.Tensor],
         loss_mask: torch.Tensor,
         lm_head_weight: torch.Tensor,
+        target_last_hidden_states: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Full DFlash training forward pass.
 
@@ -266,10 +322,16 @@ class DFlashModel(nn.Module):
         # 1. Extract context features from target hidden states
         context_feature = self.draft_model.extract_context_feature(hidden_states_list)
 
-        # 2. Sample anchor positions with validity mask
-        anchor_positions, block_keep_mask = self._sample_anchor_positions(
-            seq_len, loss_mask, device
-        )
+        # 2. Sample anchor positions (DSpark uses a DeepSpec-faithful sampler; see
+        # _sample_anchor_positions_dspark)
+        if self.loss_objective == "dspark":
+            anchor_positions, block_keep_mask = self._sample_anchor_positions_dspark(
+                seq_len, loss_mask, device
+            )
+        else:
+            anchor_positions, block_keep_mask = self._sample_anchor_positions(
+                seq_len, loss_mask, device
+            )
         n_blocks = anchor_positions.shape[1]
 
         # 3. Create noise embeddings (anchor token + MASK tokens)
@@ -318,71 +380,129 @@ class DFlashModel(nn.Module):
             else F.linear(draft_hidden, lm_head_weight)
         )
 
-        # 8. Compute labels and weight mask (SpecForge pattern)
-        # Labels: same-position prediction (position k predicts token at anchor+k)
-        label_offsets = torch.arange(0, self.block_size, device=device).view(1, 1, -1)
-        label_indices = anchor_positions.unsqueeze(-1) + label_offsets  # [B, n_blocks, block_size]
-        valid_label_mask = label_indices < seq_len
-        safe_label_indices = label_indices.clamp(max=seq_len - 1)
+        # 8. Compute labels and weight mask.
+        is_dspark = self.loss_objective == "dspark"
+        if is_dspark:
+            # DeepSpec next-token convention: slot j predicts anchor+j+1, all slots
+            # supervised; eval_mask = contiguous supervised prefix per block (cumprod).
+            label_offsets = torch.arange(1, self.block_size + 1, device=device).view(1, 1, -1)
+            label_indices = anchor_positions.unsqueeze(-1) + label_offsets
+            valid_label_mask = label_indices < seq_len
+            safe_label_indices = label_indices.clamp(max=seq_len - 1)
+            safe_label_indices = torch.where(
+                block_keep_mask.unsqueeze(-1),
+                safe_label_indices,
+                torch.zeros_like(safe_label_indices),
+            )
+            target_ids = torch.gather(
+                input_ids.unsqueeze(1).expand(-1, n_blocks, -1), 2, safe_label_indices
+            )
+            target_loss_mask_gathered = torch.gather(
+                loss_mask.unsqueeze(1).expand(-1, n_blocks, -1), 2, safe_label_indices
+            )
+            eval_bool = (
+                block_keep_mask.unsqueeze(-1) & valid_label_mask & (target_loss_mask_gathered > 0.5)
+            )
+            eval_bool = eval_bool.to(torch.int32).cumprod(dim=-1).bool()
+            weight_mask = eval_bool.float()
+        else:
+            # DFlash same-position / infill convention (position k predicts anchor+k);
+            # slot 0 is the anchor token and carries no loss.
+            label_offsets = torch.arange(0, self.block_size, device=device).view(1, 1, -1)
+            label_indices = anchor_positions.unsqueeze(-1) + label_offsets
+            valid_label_mask = label_indices < seq_len
+            safe_label_indices = label_indices.clamp(max=seq_len - 1)
 
-        target_ids = torch.gather(
-            input_ids.unsqueeze(1).expand(-1, n_blocks, -1),
-            2,
-            safe_label_indices,
-        )  # [B, n_blocks, block_size]
+            target_ids = torch.gather(
+                input_ids.unsqueeze(1).expand(-1, n_blocks, -1),
+                2,
+                safe_label_indices,
+            )  # [B, n_blocks, block_size]
 
-        # Weight mask: block validity × bounds × exclude anchor (pos 0) × loss_mask
-        weight_mask = block_keep_mask.unsqueeze(-1).expand(-1, -1, self.block_size).float()
-        weight_mask = weight_mask * valid_label_mask.float()
+            # Weight mask: block validity × bounds × exclude anchor (pos 0) × loss_mask
+            weight_mask = block_keep_mask.unsqueeze(-1).expand(-1, -1, self.block_size).float()
+            weight_mask = weight_mask * valid_label_mask.float()
 
-        pos_in_block = torch.arange(self.block_size, device=device).view(1, 1, -1)
-        weight_mask = weight_mask * (pos_in_block > 0).float()
+            pos_in_block = torch.arange(self.block_size, device=device).view(1, 1, -1)
+            weight_mask = weight_mask * (pos_in_block > 0).float()
 
-        # Gather original loss_mask at label positions
-        original_loss_mask_gathered = torch.gather(
-            loss_mask.unsqueeze(1).expand(-1, n_blocks, -1),
-            2,
-            safe_label_indices,
-        )
-        weight_mask = weight_mask * original_loss_mask_gathered
+            # Gather original loss_mask at label positions
+            original_loss_mask_gathered = torch.gather(
+                loss_mask.unsqueeze(1).expand(-1, n_blocks, -1),
+                2,
+                safe_label_indices,
+            )
+            weight_mask = weight_mask * original_loss_mask_gathered
 
         # Capture binary mask BEFORE applying objective weights. Accuracy measures
         # "did we predict correctly?" uniformly across positions, while weighting
-        # only shapes gradient contribution. SpecForge uses no decay at all;
-        # our objective weighting is an addition to the training signal, not the metric.
+        # only shapes gradient contribution.
         binary_eval_mask = weight_mask.view(-1)
 
-        # 9. Cross entropy loss
+        # 8b. Teacher-forced previous-token ids for the Markov head: DSpark seeds slot 0
+        # with the anchor token, DFlash with the same-position token (see DFlashMarkovHead).
+        markov_head = getattr(self.draft_model, "markov_head", None)
+        if is_dspark:
+            anchor_token_ids = torch.gather(input_ids, 1, anchor_positions.clamp(0, seq_len - 1))
+            prev_token_ids = torch.cat(
+                [anchor_token_ids.unsqueeze(-1), target_ids[:, :, :-1]], dim=-1
+            )
+        else:
+            prev_token_ids = torch.cat([target_ids[:, :, :1], target_ids[:, :, :-1]], dim=-1)
+        if markov_head is not None:
+            logits_by_block = logits.view(bsz, n_blocks, self.block_size, -1)
+            logits_by_block = markov_head.apply_block_logits(logits_by_block, prev_token_ids)
+            logits = logits_by_block.reshape(bsz, n_blocks * self.block_size, -1)
+
+        # 9. Loss
         flat_logits = logits.view(-1, logits.size(-1))
         flat_targets = target_ids.view(-1)
         loss_per_token = F.cross_entropy(flat_logits, flat_targets, reduction="none")
         loss_per_token_by_position = loss_per_token.view(bsz, n_blocks, self.block_size)
 
-        objective_weights = weight_mask
-        if (
-            self.loss_objective == "decay"
-            and self.loss_decay_gamma is not None
-            and self.loss_decay_gamma > 0
-        ):
-            # Loss decay: exp(-(k-1)/γ) so k=1 (1st prediction) gets weight 1.0
+        # Position decay weights: DSpark uses exp(-k/γ) (slot 0 = first prediction);
+        # DFlash decay/dpace use exp(-(k-1)/γ) since their slot 0 is the masked anchor.
+        decay_weights = None
+        if self.loss_decay_gamma is not None and self.loss_decay_gamma > 0:
             k = torch.arange(self.block_size, device=device).view(1, 1, -1)
-            decay_weights = torch.exp(-(k - 1).clamp(min=0).float() / self.loss_decay_gamma)
-            objective_weights = weight_mask * decay_weights
-        elif self.loss_objective == "dpace":
-            dpace_weights = torch.ones_like(weight_mask)
-            if self.block_size > 1:
-                with torch.no_grad():
-                    target_confidences = torch.exp(-loss_per_token_by_position[..., 1:].float())
-                    dpace_pred_weights = _dpace_position_weights(
-                        target_confidences,
-                        self.dpace_alpha,
-                    ).to(dtype=weight_mask.dtype)
-                dpace_weights[..., 1:] = dpace_pred_weights
-            objective_weights = weight_mask * dpace_weights
+            if is_dspark:
+                decay_weights = torch.exp(-k.float() / self.loss_decay_gamma)
+            else:
+                decay_weights = torch.exp(-(k - 1).clamp(min=0).float() / self.loss_decay_gamma)
 
-        flat_weights = objective_weights.view(-1)
-        valid_token_count = flat_weights.sum().clamp(min=1e-6)
-        loss = (loss_per_token * flat_weights).sum() / valid_token_count
+        if self.loss_objective == "dspark":
+            loss = self._dspark_loss(
+                flat_logits=flat_logits,
+                loss_per_token=loss_per_token,
+                draft_hidden=draft_hidden,
+                weight_mask=weight_mask,
+                decay_weights=decay_weights,
+                label_indices=label_indices,
+                target_last_hidden_states=target_last_hidden_states,
+                lm_head_weight=lm_head_weight,
+                bsz=bsz,
+                n_blocks=n_blocks,
+                prev_token_ids=prev_token_ids,
+            )
+        else:
+            objective_weights = weight_mask
+            if self.loss_objective == "decay" and decay_weights is not None:
+                objective_weights = weight_mask * decay_weights
+            elif self.loss_objective == "dpace":
+                dpace_weights = torch.ones_like(weight_mask)
+                if self.block_size > 1:
+                    with torch.no_grad():
+                        target_confidences = torch.exp(-loss_per_token_by_position[..., 1:].float())
+                        dpace_pred_weights = _dpace_position_weights(
+                            target_confidences,
+                            self.dpace_alpha,
+                        ).to(dtype=weight_mask.dtype)
+                    dpace_weights[..., 1:] = dpace_pred_weights
+                objective_weights = weight_mask * dpace_weights
+
+            flat_weights = objective_weights.view(-1)
+            valid_token_count = flat_weights.sum().clamp(min=1e-6)
+            loss = (loss_per_token * flat_weights).sum() / valid_token_count
 
         # 10. Accuracy (using binary mask without decay)
         with torch.no_grad():
@@ -406,3 +526,124 @@ class DFlashModel(nn.Module):
             ) / count_per_pos
 
         return loss, accuracy, loss_per_position, acc_per_position, count_per_position
+
+    def _dspark_loss(
+        self,
+        *,
+        flat_logits: torch.Tensor,
+        loss_per_token: torch.Tensor,
+        draft_hidden: torch.Tensor,
+        weight_mask: torch.Tensor,
+        decay_weights: Optional[torch.Tensor],
+        label_indices: torch.Tensor,
+        target_last_hidden_states: Optional[torch.Tensor],
+        lm_head_weight: torch.Tensor,
+        bsz: int,
+        n_blocks: int,
+        prev_token_ids: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """DSpark objective: CE + TV/L1 distribution matching (+ optional confidence BCE).
+
+        Faithful to DeepSpec (deepspec/modeling/dspark/loss.py): the three terms share a
+        single token-pooled denominator (eval_mask x decay). The backward loss divides the
+        summed numerators by the global denominator (all-reduced across ranks) and scales
+        by world_size to cancel FSDP's mean gradient reduction — a true global token mean
+        rather than a mean-of-per-rank-means; identical to a local mean at world_size==1.
+        Target probabilities are built lazily from the target model's final hidden state
+        and the frozen LM head, on supervised rows only (off-by-one: the target dist over
+        the token at label position j comes from the target hidden at j-1). Logged
+        per-component values use the local denominator.
+        """
+        if target_last_hidden_states is None:
+            raise ValueError(
+                "loss_objective='dspark' requires target_last_hidden_states (the target "
+                "model's final pre-LM-head hidden state). Enable store_last_hidden_states "
+                "on the inference engine and forward batch['last_hidden_states']"
+            )
+
+        block_size = self.block_size
+        draft_len = n_blocks * block_size
+        hidden = draft_hidden.size(-1)
+        seq_len = target_last_hidden_states.size(1)
+
+        # Single token-pooled weight = eval mask x optional decay (DeepSpec loss_weight_mask).
+        weight = weight_mask if decay_weights is None else weight_mask * decay_weights
+        flat_weight = weight.reshape(-1)
+        local_den = flat_weight.sum()
+
+        # CE numerator over all supervised positions.
+        ce_num = (loss_per_token * flat_weight).sum()
+
+        zero = flat_logits.new_zeros(())
+        l1_num = zero
+        conf_num = zero
+        valid_idx = (flat_weight > 0).nonzero(as_tuple=True)[0]
+        if valid_idx.numel() > 0:
+            weight_valid = flat_weight[valid_idx]
+            draft_logits_valid = flat_logits[valid_idx]  # [Nv, V] (markov-corrected)
+
+            # Lazy target logits: gather target hidden at (label_index - 1), frozen LM head,
+            # supervised rows only — never a full-vocab x all-slots tensor.
+            target_pred_indices = (label_indices - 1).clamp(min=0, max=seq_len - 1)
+            gather_idx = (
+                target_pred_indices.reshape(bsz, draft_len)
+                .unsqueeze(-1)
+                .expand(bsz, draft_len, hidden)
+            )
+            aligned_target_hidden = torch.gather(target_last_hidden_states, 1, gather_idx)
+            aligned_target_hidden = aligned_target_hidden.reshape(-1, hidden)[valid_idx]
+            target_logits_valid = F.linear(
+                aligned_target_hidden.to(lm_head_weight.dtype), lm_head_weight
+            )
+
+            draft_probs = torch.softmax(draft_logits_valid.float(), dim=-1)
+            target_probs = torch.softmax(target_logits_valid.float(), dim=-1)
+            l1_per_valid = (draft_probs - target_probs).abs().sum(dim=-1)
+            l1_num = (l1_per_valid * weight_valid).sum()
+
+            # Optional confidence head: BCE against the TV acceptance estimate (detached).
+            confidence_head = getattr(self.draft_model, "confidence_head", None)
+            if confidence_head is not None:
+                accept_rate = (1.0 - 0.5 * l1_per_valid).clamp(0.0, 1.0).detach()
+                draft_hidden_valid = draft_hidden.reshape(-1, hidden)[valid_idx]
+                with_markov = bool(getattr(self.draft_model, "confidence_head_with_markov", False))
+                if with_markov and prev_token_ids is not None:
+                    prev_emb = self.draft_model.markov_head.get_prev_embeddings(prev_token_ids)
+                    prev_emb = prev_emb.reshape(-1, prev_emb.size(-1))[valid_idx].to(
+                        draft_hidden_valid.dtype
+                    )
+                    conf_features = torch.cat([draft_hidden_valid, prev_emb], dim=-1)
+                else:
+                    conf_features = draft_hidden_valid
+                conf_logits_valid = confidence_head(conf_features).reshape(-1).float()
+                bce = F.binary_cross_entropy_with_logits(
+                    conf_logits_valid, accept_rate, reduction="none"
+                )
+                conf_num = (bce * weight_valid).sum()
+
+        # Logged per-component values (local token means).
+        den_eps = local_den + 1e-6
+        self._dspark_components = {
+            "dspark_ce": (ce_num / den_eps).detach(),
+            "dspark_l1": (l1_num / den_eps).detach(),
+            "dspark_conf": (conf_num / den_eps).detach(),
+        }
+
+        # Backward loss: global token-pooled mean x world_size (DeepSpec _build_loss).
+        global_den = local_den.detach().clone()
+        world_size = 1
+        if dist.is_available() and dist.is_initialized():
+            world_size = dist.get_world_size()
+            if world_size > 1:
+                dist.all_reduce(global_den, op=dist.ReduceOp.SUM)
+        global_den = global_den + 1e-6
+        total = (
+            (
+                self.dspark_ce_alpha * ce_num
+                + self.dspark_l1_alpha * l1_num
+                + self.dspark_confidence_alpha * conf_num
+            )
+            / global_den
+            * world_size
+        )
+        return total

--- a/torchspec/models/draft/dflash.py
+++ b/torchspec/models/draft/dflash.py
@@ -60,6 +60,10 @@ class DFlashConfig(PretrainedConfig):
         target_num_hidden_layers: int = 36,
         target_layer_ids: Optional[List[int]] = None,
         mask_token_id: int = 151669,
+        markov_rank: int = 0,
+        markov_head_type: str = "vanilla",
+        enable_confidence_head: bool = False,
+        confidence_head_with_markov: bool = False,
         tie_word_embeddings: bool = False,
         **kwargs,
     ):
@@ -78,6 +82,20 @@ class DFlashConfig(PretrainedConfig):
         self.target_num_hidden_layers = target_num_hidden_layers
         self.target_layer_ids = target_layer_ids
         self.mask_token_id = mask_token_id
+        # DSpark "Markov head": low-rank, previous-token-conditioned bias on the draft
+        # logits. markov_rank == 0 (default) disables it entirely — no parameters and no
+        # behavior change. Only the "vanilla" head type is supported in TorchSpec.
+        self.markov_rank = markov_rank
+        self.markov_head_type = markov_head_type
+        # DSpark confidence head: per-position acceptance predictor (Linear hidden->1)
+        # trained with BCE vs the TV acceptance estimate. Consumed by the serving engine
+        # for per-block early-stop. Disabled by default (no params, no behavior change).
+        # Field name matches DeepSpec/DSpark (enable_confidence_head) for serving interop.
+        self.enable_confidence_head = enable_confidence_head
+        # DSpark: when True, the confidence head also consumes the Markov head's
+        # previous-token embedding (input dim = hidden_size + markov_rank), matching
+        # DeepSpec's confidence_head_with_markov. Requires markov_rank > 0.
+        self.confidence_head_with_markov = confidence_head_with_markov
 
 
 class DFlashRMSNorm(nn.Module):
@@ -344,6 +362,77 @@ def build_target_layer_ids(num_target_layers: int, num_hidden_layers: int) -> Li
     ]
 
 
+class DFlashMarkovHead(nn.Module):
+    """Low-rank, previous-token-conditioned logit bias (DSpark "Markov head", vanilla).
+
+    Adds ``W2(W1[prev_token])`` to the draft logits, where ``W1`` is an
+    ``Embedding(vocab_size, markov_rank)`` and ``W2`` is a ``Linear(markov_rank,
+    vocab_size)`` — a rank-``markov_rank`` factorization of a per-previous-token logit
+    bias. This reintroduces the intra-block token dependency the parallel block drafter
+    otherwise loses. Training applies the bias teacher-forced; the serving engine applies
+    the same bias autoregressively while sampling each block.
+    """
+
+    def __init__(self, vocab_size: int, markov_rank: int):
+        super().__init__()
+        self.vocab_size = int(vocab_size)
+        self.markov_rank = int(markov_rank)
+        self.markov_w1 = nn.Embedding(self.vocab_size, self.markov_rank)
+        self.markov_w2 = nn.Linear(self.markov_rank, self.vocab_size, bias=False)
+
+    def compute_bias(self, prev_token_ids: torch.Tensor) -> torch.Tensor:
+        """Per-position logit bias for the previous tokens: [...] -> [..., vocab_size]."""
+        return self.markov_w2(self.markov_w1(prev_token_ids.long()))
+
+    def get_prev_embeddings(self, prev_token_ids: torch.Tensor) -> torch.Tensor:
+        """Low-rank previous-token embedding: [...] -> [..., markov_rank].
+
+        Used by the DSpark confidence head when confidence_head_with_markov is set.
+        """
+        return self.markov_w1(prev_token_ids.long())
+
+    def apply_block_logits(
+        self, base_logits: torch.Tensor, prev_token_ids: torch.Tensor
+    ) -> torch.Tensor:
+        """Add the Markov bias to block-structured logits.
+
+        Args:
+            base_logits: [B, num_blocks, block_size, vocab_size]
+            prev_token_ids: [B, num_blocks, block_size] — previous (teacher-forced) token per slot
+        """
+        return base_logits + self.compute_bias(prev_token_ids)
+
+
+def build_dflash_markov_head(config: PretrainedConfig) -> Optional["DFlashMarkovHead"]:
+    """Build the optional Markov head; returns None when disabled (markov_rank == 0)."""
+    markov_rank = int(getattr(config, "markov_rank", 0) or 0)
+    if markov_rank <= 0:
+        return None
+    head_type = str(getattr(config, "markov_head_type", "vanilla")).lower()
+    if head_type != "vanilla":
+        raise ValueError(f"DFlash supports only markov_head_type='vanilla', got {head_type!r}")
+    return DFlashMarkovHead(vocab_size=config.vocab_size, markov_rank=markov_rank)
+
+
+class DFlashAcceptRatePredictor(nn.Module):
+    """DSpark confidence head: per-position acceptance-probability predictor.
+
+    A single ``Linear(input_dim -> 1)`` producing a logit (apply sigmoid for the
+    acceptance probability). ``input_dim`` is ``hidden_size`` normally, or
+    ``hidden_size + markov_rank`` when ``confidence_head_with_markov`` is set (the
+    Markov previous-token embedding is concatenated to the hidden state). Trained with
+    BCE against the TV acceptance estimate ``1 - 0.5*|draft_probs - target_probs|``;
+    the serving engine consumes the sigmoid output for per-block early-stop.
+    """
+
+    def __init__(self, input_dim: int):
+        super().__init__()
+        self.proj = nn.Linear(int(input_dim), 1)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.proj(hidden_states).squeeze(-1)
+
+
 class DFlashDraftModel(PreTrainedModel):
     """DFlash draft model with dual-source KV injection.
 
@@ -389,6 +478,26 @@ class DFlashDraftModel(PreTrainedModel):
 
         # Final norm
         self.final_norm = DFlashRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        # Optional DSpark Markov head — None when markov_rank == 0 (no params added).
+        self.markov_head = build_dflash_markov_head(config)
+
+        # Optional DSpark confidence head — None unless explicitly enabled. When
+        # confidence_head_with_markov is set, the head also consumes the Markov
+        # previous-token embedding (input dim = hidden_size + markov_rank), matching
+        # DeepSpec's AcceptRatePredictor.
+        self.confidence_head_with_markov = bool(
+            getattr(config, "confidence_head_with_markov", False)
+        )
+        self.confidence_head = None
+        if getattr(config, "enable_confidence_head", False):
+            conf_input_dim = config.hidden_size
+            if self.confidence_head_with_markov:
+                markov_rank = int(getattr(config, "markov_rank", 0) or 0)
+                if markov_rank <= 0:
+                    raise ValueError("confidence_head_with_markov=True requires markov_rank > 0")
+                conf_input_dim += markov_rank
+            self.confidence_head = DFlashAcceptRatePredictor(conf_input_dim)
 
     def extract_context_feature(self, all_hidden_states: List[torch.Tensor]) -> torch.Tensor:
         """Extract and project context features from target hidden states.

--- a/torchspec/training/dflash_trainer.py
+++ b/torchspec/training/dflash_trainer.py
@@ -52,6 +52,9 @@ class DFlashTrainer(Trainer):
         self.loss_objective = getattr(args, "dflash_loss_objective", "decay")
         self.dpace_alpha = getattr(args, "dflash_dpace_alpha", 0.5)
         self.loss_decay_gamma = getattr(args, "dflash_loss_decay_gamma", 7.0)
+        self.dspark_ce_alpha = getattr(args, "dflash_dspark_ce_alpha", 0.1)
+        self.dspark_l1_alpha = getattr(args, "dflash_dspark_l1_alpha", 0.9)
+        self.dspark_confidence_alpha = getattr(args, "dflash_dspark_confidence_alpha", 1.0)
 
     def init_model(
         self,
@@ -128,6 +131,9 @@ class DFlashTrainer(Trainer):
             loss_objective=self.loss_objective,
             dpace_alpha=self.dpace_alpha,
             loss_decay_gamma=self.loss_decay_gamma,
+            dspark_ce_alpha=self.dspark_ce_alpha,
+            dspark_l1_alpha=self.dspark_l1_alpha,
+            dspark_confidence_alpha=self.dspark_confidence_alpha,
         )
 
         full_state = dflash_model.state_dict() if dist.get_rank() == 0 else {}
@@ -270,11 +276,26 @@ class DFlashTrainer(Trainer):
         hidden_states_list = self._split_hidden_states(hidden_states)
         del hidden_states
 
+        # DSpark objective needs the target's final pre-LM-head hidden state to build
+        # target distributions (TV/L1 + confidence BCE). It is already shipped via
+        # Mooncake under 'last_hidden_states'; only fetch/forward it when needed.
+        target_last_hidden_states = None
+        if self.loss_objective == "dspark":
+            tlhs = batch.get("last_hidden_states")
+            if tlhs is None:
+                raise ValueError(
+                    "loss_objective='dspark' requires 'last_hidden_states' in the batch, "
+                    "but none was found. Enable store_last_hidden_states on the inference "
+                    "engine (captured by default for HF/vLLM; set it explicitly for SGLang)."
+                )
+            target_last_hidden_states = tlhs.to(device, non_blocking=True)
+
         loss, accuracy, loss_per_position, acc_per_position, count_per_position = self.model(
             input_ids=input_ids,
             hidden_states_list=hidden_states_list,
             loss_mask=loss_mask,
             lm_head_weight=self.target_lm_head_weight,
+            target_last_hidden_states=target_last_hidden_states,
         )
 
         return loss, accuracy, loss_per_position, acc_per_position, count_per_position
@@ -438,7 +459,7 @@ class DFlashTrainer(Trainer):
         total_loss = self._backward(loss, accumulation_steps=accumulation_steps)
         evt_bwd_e.record()
 
-        return {
+        step_metrics = {
             "loss": loss.detach(),
             "accuracy": accuracy.detach(),
             "loss_per_position": loss_per_position.detach(),
@@ -448,6 +469,12 @@ class DFlashTrainer(Trainer):
             "_fwd_events": (evt_fwd_s, evt_fwd_e),
             "_bwd_events": (evt_bwd_s, evt_bwd_e),
         }
+        # Best-effort DSpark component losses (ce/l1/confidence) stashed by the forward.
+        dspark_components = getattr(self.dflash, "_dspark_components", None)
+        if dspark_components:
+            for name, value in dspark_components.items():
+                step_metrics[name] = value.detach() if torch.is_tensor(value) else value
+        return step_metrics
 
     def _aggregate_metrics(
         self, all_step_metrics: list[dict], step: int, *, grad_norm: torch.Tensor = None
@@ -492,6 +519,12 @@ class DFlashTrainer(Trainer):
         for i in range(pred_loss_pp.shape[0]):
             metrics[f"train/ploss_{i}"] = pred_loss_pp[i].item()
             metrics[f"train/acc_{i}"] = pred_acc_pp[i].item()
+
+        # DSpark objective component losses (only present when objective == "dspark").
+        for comp_key in ("dspark_ce", "dspark_l1", "dspark_conf"):
+            vals = [m[comp_key] for m in all_step_metrics if comp_key in m]
+            if vals:
+                metrics[f"train/{comp_key}"] = torch.stack([v.float() for v in vals]).mean().item()
 
         # Sub-timing breakdown (forward vs backward)
         fwd_ms = sum(


### PR DESCRIPTION
## Summary

Implement DeepSeek DeepSpec's DSpark draft-training objective as a `dspark`
`loss_objective` on the existing DFlash drafter. DSpark and DFlash are the same
block-parallel anchor drafter: DeepSpec realizes DSpark as that drafter [1] plus
a low-rank Markov head [2], a per-position confidence head, and a
distribution-matching loss [3]. TorchSpec already ships the drafter as DFlash, so
DSpark reuses that code path (dual-source KV, block-causal FlexAttention,
anchor/noise machinery) and is added as a `loss_objective` with two optional
heads, rather than a separate model/trainer stack. A separate-stack port of
DSpark also exists (#129); both are faithful to DeepSpec, and this one keeps a
single code path for the shared DFlash backbone.

[1] https://github.com/deepseek-ai/DeepSpec/blob/dd854392fadf053cfddcbc4dc0e6e32de46d1bd0/deepspec/modeling/dspark/qwen3/modeling.py
[2] https://github.com/deepseek-ai/DeepSpec/blob/dd854392fadf053cfddcbc4dc0e6e32de46d1bd0/deepspec/modeling/dspark/markov_head.py
[3] https://github.com/deepseek-ai/DeepSpec/blob/dd854392fadf053cfddcbc4dc0e6e32de46d1bd0/deepspec/modeling/dspark/loss.py

## Scope (dspark-only; the DFlash decay/dpace paths are unchanged)

- next-token labels (slot j predicts anchor+j+1), all `block_size` slots supervised
- contiguous-prefix eval mask (cumprod)
- anchor-seeded Markov previous token
- anchor sampling that requires both the anchor and its first target to be valid
- global token-pooled loss normalization (cross-rank all-reduce × world_size)
- low-rank vanilla Markov head + confidence head (optional Markov-feature fusion)
- CE + TV/L1 distribution distillation (against the target LM head applied to its final hidden state) + confidence BCE

## Testing

- `pytest tests/test_dspark.py` — 8 CPU tests pass: forward shape/finiteness, loss decomposition, all-masked → 0, next-token supervises all block slots, grad flow + frozen embedding, Markov bias == W2(W1[prev]), linear confidence head, and numerical faithfulness vs the vendored DeepSpec reference loss.
- `ruff check` and `ruff format --check` clean on all changed files.
- Validated component-wise against the DeepSpec reference loss/forward and on the GPU FlexAttention path. Qwen3-8B recipe: `block_size=7, gamma=4.0, markov_rank=256`.
