### PR TITLE
fix(training): neutralize sub-threshold loss masks instead of per-ran…

### DIFF
--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -143,6 +143,41 @@ class TestMooncakeDataset:
 
         assert len(samples) == 1
 
+    def test_subthreshold_samples_neutralized_not_dropped(self):
+        """Empty / sub-min_loss_tokens samples are kept as zero-mask micro-batches,
+        not dropped — a per-rank drop would desync FSDP collectives."""
+
+        def packed(mask):
+            return serialize_packed_loss_mask(pack_loss_mask(mask))
+
+        ray_queue = MockRayQueue()
+        store = MockMooncakeStore()
+        masks = {
+            "sub": torch.tensor([0, 0, 1, 1, 0, 0, 0, 0], dtype=torch.long),  # sum 2 < 4
+            "valid": torch.tensor([0, 0, 1, 1, 1, 1, 1, 1], dtype=torch.long),  # sum 6
+            "empty": torch.zeros(8, dtype=torch.long),  # sum 0
+        }
+        for key, mask in masks.items():
+            ray_queue.put(
+                TrainSample(
+                    mooncake_key=key,
+                    tensor_shapes={"input_ids": (8,)},
+                    tensor_dtypes={"input_ids": torch.long},
+                    packed_loss_mask=packed(mask),
+                )
+            )
+        ray_queue.put(None)
+
+        dataset = MooncakeDataset(ray_queue, store, torch.device("cpu"), min_loss_tokens=4)
+        samples = list(dataset)
+
+        # Count preserved (lockstep): every dispatched sample yields one micro-batch.
+        assert len(samples) == 3
+        sub, valid, empty = samples
+        assert not sub["loss_mask"].any()
+        assert valid["loss_mask"].any()
+        assert not empty["loss_mask"].any()
+
     def test_usp_sharded_keeps_local_zero_loss_shard_when_global_loss_exists(self):
         """A local all-zero USP shard must not be skipped independently.
 
@@ -195,7 +230,7 @@ class TestMooncakeDataset:
             dataset._sp_rank = sp_rank
             dataset._sp_ring_size = 1
 
-            tensors, skipped = dataset._usp_get_sharded_item(skip_count=0)
+            tensors, skipped = dataset._usp_get_sharded_item(neutralized_count=0)
             outputs.append((tensors, skipped))
 
         rank0_tensors, rank0_skipped = outputs[0]

--- a/torchspec/training/data_fetcher.py
+++ b/torchspec/training/data_fetcher.py
@@ -187,45 +187,63 @@ class MooncakeDataset(IterableDataset):
             skip_after_header=self.skip_after_header,
         )
 
-    def _should_skip_for_loss_mask(
-        self, data: Dict[str, Any], mooncake_key: str, skip_count: int
-    ) -> tuple[bool, int]:
-        mask = self._compute_loss_mask(data)
-        if mask is None:
-            skip_count += 1
-            logger.warning(
-                f"Skipping sample with all-zero loss mask "
-                f"(mooncake_key={mooncake_key}, total_skipped={skip_count})"
-            )
-            return True, skip_count
+    @staticmethod
+    def _fallback_mask_len(data: Dict[str, Any]) -> int:
+        """Sequence length for a neutralized sample's zero loss mask."""
+        ids = data.get("input_ids")
+        if isinstance(ids, torch.Tensor) and ids.dim() >= 1:
+            return ids.shape[-1]
+        for key in ("hidden_states", "last_hidden_states", "target"):
+            t = data.get(key)
+            if isinstance(t, torch.Tensor) and t.dim() >= 2:
+                return t.shape[-2]
+        return 1
 
-        if (
+    def _resolve_and_neutralize_loss_mask(
+        self, data: Dict[str, Any], mooncake_key: str, neutralized_count: int
+    ) -> int:
+        """Zero an empty / sub-min_loss_tokens loss mask in place instead of
+        dropping the sample; a per-rank drop desyncs FSDP collectives."""
+        mask = self._compute_loss_mask(data)  # None == all-zero
+        neutralize = mask is None or (
             self._min_loss_tokens > 0
             and isinstance(mask, torch.Tensor)
             and mask.sum() < self._min_loss_tokens
-        ):
-            skip_count += 1
-            logger.warning(
-                f"Skipping sample with too few loss-masked tokens "
-                f"({int(mask.sum())} < {self._min_loss_tokens}, "
-                f"mooncake_key={mooncake_key}, total_skipped={skip_count})"
-            )
-            return True, skip_count
+        )
+        if not neutralize:
+            return neutralized_count
 
-        return False, skip_count
+        if isinstance(mask, torch.Tensor):
+            n_tokens = int(mask.sum())
+            data["loss_mask"] = torch.zeros_like(mask)
+        else:
+            # resolve_loss_mask returns None without setting data["loss_mask"]
+            n_tokens = 0
+            data["loss_mask"] = torch.zeros(self._fallback_mask_len(data), dtype=torch.long)
+
+        neutralized_count += 1
+        logger.warning(
+            f"Neutralized loss mask ({n_tokens} < min_loss_tokens="
+            f"{self._min_loss_tokens}, mooncake_key={mooncake_key}, "
+            f"total_neutralized={neutralized_count})"
+        )
+        return neutralized_count
 
     def __iter__(self) -> Iterator[Dict[str, torch.Tensor]]:
         """Iterate over samples synchronously.
 
         Blocks waiting for each item from the queue and loads from mooncake.
-        Skips samples whose loss mask is all zeros to avoid wasted compute.
+        Empty / sub-min_loss_tokens masks are neutralized, not dropped
+        (see _resolve_and_neutralize_loss_mask).
         """
         yield_count = 0
-        skip_count = 0
+        neutralized_count = 0
         while True:
             if self.usp_enabled:
-                data, skipped = self._usp_get_sharded_item(skip_count=skip_count)
-                skip_count += skipped
+                data, neutralized = self._usp_get_sharded_item(
+                    neutralized_count=neutralized_count
+                )
+                neutralized_count += neutralized
                 if data is None:
                     break
                 yield_count += 1
@@ -246,11 +264,9 @@ class MooncakeDataset(IterableDataset):
             logger.debug(f"__iter__: got item, mooncake_key={item.mooncake_key}")
             data = self._load_from_mooncake(item)
 
-            should_skip, skip_count = self._should_skip_for_loss_mask(
-                data, item.mooncake_key, skip_count
+            neutralized_count = self._resolve_and_neutralize_loss_mask(
+                data, item.mooncake_key, neutralized_count
             )
-            if should_skip:
-                continue
 
             # Note: target is computed in the collator from last_hidden_states for sglang mode
 
@@ -358,8 +374,10 @@ class MooncakeDataset(IterableDataset):
         min_tokens = max(1, self._min_loss_tokens)
         return int(full_loss_mask.sum().item()) < min_tokens
 
-    def _usp_get_sharded_item(self, skip_count: int) -> tuple[Dict[str, torch.Tensor] | None, int]:
-        skipped = 0
+    def _usp_get_sharded_item(
+        self, neutralized_count: int
+    ) -> tuple[Dict[str, torch.Tensor] | None, int]:
+        neutralized = 0
         while True:
             try:
                 item = self.ray_queue.get(block=True, timeout=self.timeout)
@@ -368,9 +386,9 @@ class MooncakeDataset(IterableDataset):
                     f"_usp_get_sharded_item: Exception waiting for data: {e}, "
                     f"timeout={self.timeout}"
                 )
-                return None, skipped
+                return None, neutralized
             if item is None:
-                return None, skipped
+                return None, neutralized
 
             metadata = item.metadata or {}
             if not metadata.get("usp_sharded", False):
@@ -405,16 +423,16 @@ class MooncakeDataset(IterableDataset):
             )
 
             if should_skip:
-                skipped += 1
-                total_skipped = skip_count + skipped
+                # Neutralize, don't drop: a per-DP-group drop desyncs FSDP.
+                neutralized += 1
+                tensors["loss_mask"] = torch.zeros_like(tensors["loss_mask"])
                 logger.warning(
-                    f"Skipping USP sharded sample with global all-zero loss mask "
-                    f"(mooncake_key={item.mooncake_key}, sp_rank={self._sp_rank}, "
-                    f"total_skipped={total_skipped})"
+                    f"Neutralized USP sharded sample (loss mask zeroed): "
+                    f"mooncake_key={item.mooncake_key}, sp_rank={self._sp_rank}, "
+                    f"total_neutralized={neutralized_count + neutralized}"
                 )
-                continue
 
-            return tensors, skipped
+            return tensors, neutralized
 
 
 def create_mooncake_dataloader(

--- a/torchspec/training/data_fetcher.py
+++ b/torchspec/training/data_fetcher.py
@@ -240,9 +240,7 @@ class MooncakeDataset(IterableDataset):
         neutralized_count = 0
         while True:
             if self.usp_enabled:
-                data, neutralized = self._usp_get_sharded_item(
-                    neutralized_count=neutralized_count
-                )
+                data, neutralized = self._usp_get_sharded_item(neutralized_count=neutralized_count)
                 neutralized_count += neutralized
                 if data is None:
                     break


### PR DESCRIPTION
Close #126 

## Summary

Multi-rank FSDP training can hang on an NCCL collective timeout because `DataFetcher` drops samples (empty loss mask, or `< min_loss_tokens` supervised tokens) per-rank and uncoordinated. When such a sample lands on some (not all) DP ranks in a dispatched step, the dropping rank runs one fewer micro-batch, the ranks fall out of collective lockstep and the next collective blocks until the watchdog aborts.

The bug was triggered with the example, `configs/sglang_qwen3_8b_dflash.yaml`, per described in #126, where we have `min_loss_tokens: 32`. The field was not present on all EAGLE-3 training examples.

In this PR, the data fetcher zeroes the loss mask in place and keeps the sample, so every dispatched sample still yields exactly one micro-batch. Collectives stay balanced, and a zero mask contributes 0 loss.

## Code Trace

`DataFetcher` (`torchspec/training/data_fetcher.py`) filtered in the per-rank, post-partition data path:

```python
def _should_skip_for_loss_mask(self, data, mooncake_key, skip_count):
    mask = self._compute_loss_mask(data)
    if mask is None: ...; return True, ...                 # all-zero
    if self._min_loss_tokens > 0 and mask.sum() < self._min_loss_tokens:
        ...; return True, ...                              # too few supervised tokens
    return False, ...

def __iter__(self):
    ...
    should_skip, skip_count = self._should_skip_for_loss_mask(...)
    if should_skip:
        continue                                           # ← per-rank DROP
```

The controller deals an equal `per_dp_rank_batch_size` to every rank each dispatch. Each rank sees different samples, so the drops are uncorrelated across ranks. Under FSDP every rank must issue the same sequence of all-gathers, so one rank dropping a micro-batch desyncs the group and the next collective hangs.

## The fix
Modified `torchspec/training/data_fetcher.py`.

The per-rank data path is made drop-free. Replace the skip with `_resolve_and_neutralize_loss_mask`, which keeps the sample and zeroes its loss mask:

```python
def _resolve_and_neutralize_loss_mask(self, data, mooncake_key, neutralized_count):
    mask = self._compute_loss_mask(data)                   # None == all-zero
    neutralize = mask is None or (
        self._min_loss_tokens > 0
        and isinstance(mask, torch.Tensor)
        and mask.sum() < self._min_loss_tokens
    )
    if not neutralize:
        return neutralized_count
    if isinstance(mask, torch.Tensor):
        data["loss_mask"] = torch.zeros_like(mask)
    else:                                                  # resolve returned None (no mask set)
        data["loss_mask"] = torch.zeros(self._fallback_mask_len(data), dtype=torch.long)
    ...                                                    # warn + count
    return neutralized_count
```

`__iter__` now always yields. The USP-sharded path (`_usp_get_sharded_item`) gets the same treatment. It zeroes the local shard's mask instead of skipping. `_fallback_mask_len` derives the length from `input_ids` (or `hidden_states`/`last_hidden_states`/`target`) for the all-zero case where `resolve_loss_mask` returns `None` without setting a mask.

Why this is safe:
- Count-preserving. Every dispatched sample yields exactly one micro-batch on every rank. The all-gather sequence is identical across ranks by construction.
- Covers all mask paths. Acting in the fetcher (where the mask is always computed) covers the dynamic-mask path too. However, the controller has only `packed_loss_mask` + tensor shapes ,no `input_ids`, so it cannot compute the dynamic mask. A controller filter closes the DFlash (packed) hole but leaves the dynamic-mask path's per-rank drop live. 

**Behavior change**: sub-threshold samples are processed (zeroed) rather than dropped. Loss is unaffected, only a small amount of extra compute (inference) on rare samples that satisfies the neutralize (dropping) samples were added.

## Alternatives considered

- Substitute-on-skip (pull a replacement to keep the count): Collective-safe in steady state, but needs a non-starving replacement supply and a coordinated end-of-data drain.

## Tests

- No regressions.
- Adding new tests. They fail on the old code and pass on the fix.
  - `test_subthreshold_samples_neutralized_not_dropped` (sub-threshold/empty samples are kept with zeroed masks; count preserved).
  - `test_usp_sharded_keeps_local_zero_loss_shard_when_global_loss_exists`