### PR TITLE
test: fix stale fixtures in test_loop_cleanup

### DIFF
--- a/tests/test_loop_cleanup.py
+++ b/tests/test_loop_cleanup.py
@@ -50,6 +50,7 @@ class TestTrainingLoopCleanup:
             args=args,
             inference_manager=inference_manager,
             inference_future=inference_future,
+            inference_engines=None,
         )
 
     def test_run_training_loop_finally_runs_cleanup_on_exception(self):
@@ -71,6 +72,7 @@ class TestTrainingLoopCleanup:
             args=args,
             inference_manager=inference_manager,
             inference_future=inference_future,
+            inference_engines=None,
         )
 
 
@@ -184,6 +186,7 @@ def test_setup_eval_dispatch_bs_is_dp_size():
     args = SimpleNamespace(
         eval_interval=50,
         dp_size=2,
+        inference_batch_size=4,
         max_sample_pool_size=64,
         checkpoint_dir=None,
         cache_dir="./cache",
@@ -216,6 +219,7 @@ def test_setup_eval_dispatch_bs_caps_at_dataset_size():
     args = SimpleNamespace(
         eval_interval=50,
         dp_size=8,
+        inference_batch_size=4,
         max_sample_pool_size=64,
         checkpoint_dir=None,
         cache_dir="./cache",


### PR DESCRIPTION
Four tests failed on main because the fixtures had fallen behind the
production code they exercise:

- test_run_training_loop_finally_runs_cleanup_on_{success,exception}
  asserted the _safe_training_cleanup call without inference_engines,
  but run_training_loop now forwards inference_engines to it. Add
  inference_engines=None to both assert_called_once_with calls.

- test_setup_eval_dispatch_bs_{is_dp_size,caps_at_dataset_size} built
  SimpleNamespace args lacking inference_batch_size, which setup_eval
  now reads on the eval-cache-miss branch. Add inference_batch_size=4;
  it satisfies both assertions while preserving each test's intent
  (dp_size*2 binds in the first, dataset_size cap binds in the second).

Test-only change: the production code is correct; the tests were stale.
tests/test_loop_cleanup.py now passes 9/9.
