### PR TITLE
fix(config): reject non-positive micro_batch_size at load to prevent empty-dispatch hang

### DIFF
--- a/tests/test_training_config_validation.py
+++ b/tests/test_training_config_validation.py
@@ -1,0 +1,59 @@
+"""Regression tests for training batch-size validation at config load.
+
+Guards the empty-dispatch NCCL-hang root cause behind the issue #126 surface:
+a ``training.micro_batch_size`` of 0 makes the derived ``dispatch_batch_size`` 0,
+so ``try_dispatch_batch`` no-op-dispatches (returns True while queuing nothing)
+and every rank blocks on the data-fetcher queue, surfacing as an NCCL
+all-gather timeout. The validator rejects non-positive sizes at config load,
+before any training process starts.
+"""
+
+import pytest
+from omegaconf import OmegaConf
+
+from torchspec.config.train_config import Config, load_config
+
+
+def _resolved_config(micro_batch_size: int):
+    """Build a fully-resolved config from the schema defaults + a batch-size override."""
+    config = OmegaConf.structured(Config)
+    config.training.micro_batch_size = micro_batch_size
+    return config
+
+
+def test_load_config_rejects_zero_micro_batch_size():
+    """micro_batch_size=0 must fail at load: empty dispatch -> NCCL hang."""
+    base = _resolved_config(micro_batch_size=0)
+    with pytest.raises(ValueError, match="micro_batch_size"):
+        load_config(base_config=base)
+
+
+def test_load_config_rejects_negative_micro_batch_size():
+    """Negative sizes are rejected for the same reason."""
+    base = _resolved_config(micro_batch_size=-4)
+    with pytest.raises(ValueError, match="micro_batch_size"):
+        load_config(base_config=base)
+
+
+def test_load_config_accepts_positive_micro_batch_size():
+    """Positive control: a valid size loads without raising."""
+    base = _resolved_config(micro_batch_size=2)
+    config = load_config(base_config=base)
+    assert config.training.micro_batch_size == 2
+
+
+def test_validate_training_batch_config_raises_on_zero():
+    """Directly exercise the module-level validator, not just the load_config wiring."""
+    from torchspec.config.train_config import _validate_training_batch_config
+
+    config = _resolved_config(micro_batch_size=0)
+    with pytest.raises(ValueError, match="micro_batch_size"):
+        _validate_training_batch_config(config)
+
+
+def test_validate_training_batch_config_accepts_positive():
+    """Positive control for the direct validator call."""
+    from torchspec.config.train_config import _validate_training_batch_config
+
+    config = _resolved_config(micro_batch_size=8)
+    _validate_training_batch_config(config)  # must not raise

--- a/torchspec/config/train_config.py
+++ b/torchspec/config/train_config.py
@@ -291,6 +291,15 @@ def _validate_offline_config(config: DictConfig) -> None:
             raise ValueError("inference.offline.num_engines must be positive")
 
 
+def _validate_training_batch_config(config: DictConfig) -> None:
+    if config.training.micro_batch_size < 1:
+        raise ValueError(
+            "training.micro_batch_size must be positive (>= 1): a value of 0 yields "
+            "dispatch_batch_size=0, so try_dispatch_batch no-op-dispatches and every rank "
+            "blocks on the data queue, surfacing as an NCCL all-gather timeout"
+        )
+
+
 def _save_config_snapshot(config: DictConfig) -> None:
     """Save the resolved config to output_dir/config.yaml if output_dir is set."""
     output_dir = OmegaConf.select(config, "output_dir", default=None)
@@ -337,6 +346,7 @@ def load_config(
     _validate_vllm_config(config)
     _validate_offline_config(config)
     _validate_vocab_mapping_config(config)
+    _validate_training_batch_config(config)
 
     if save_snapshot:
         _save_config_snapshot(config)


### PR DESCRIPTION
## Summary

`training.micro_batch_size` is a bare `int` field with no positivity validator. A value of `0` (a typo, or a templated config that emits `0` for a disabled head) is silently accepted at config load and cascades into a deterministic training hang with an NCCL all-gather timeout — the same surface as #126, but via an **empty-dispatch** root cause that the #138 "neutralize-never-drop" fix cannot reach.

This PR adds a single fail-fast validator at config load, mirroring the existing `_validate_offline_config` / `_validate_vocab_mapping_config` idiom.

## Root cause

- `TrainingConfig.micro_batch_size` (`train_config.py:132`) is an `int` with no `>=1` check.
- `per_dp_rank_batch_size = micro_batch_size * sp_size` (`train_entry.py`) and `dispatch_batch_size = per_dp_rank_batch_size * dp_size` (`training_controller.py:154`) are derived with no clamp.
- With `micro_batch_size=0` → `dispatch_batch_size=0`. `try_dispatch_batch` (`training_controller.py:475`) gates on `pool_size < self.dispatch_batch_size`, i.e. `pool_size < 0`, which is always `False`; it then runs `for _ in range(0)` (no-op), calls `_dispatch_to_queues([])` (puts nothing on any per-DP queue), records 0 samples, increments `batch_id`, and returns `True`.
- The training loop treats `True` as a real queued batch and eventually calls `train_from_queue(...)`, whose `MooncakeDataset.__iter__` blocks on `ray_queue.get(block=True, timeout=self.timeout)` (`data_fetcher.py:323`), where `self.timeout` defaults to `None` (no call site overrides it), so it blocks indefinitely. Every rank blocks on its empty queue; the first FSDP all-reduce never returns and NCCL times out.

This is a config-driven, deterministic trigger — no GPU/cluster state is required to reach the hang, only a bad config value.

## Relation to existing work

- #126 reported the NCCL-timeout surface; it was closed as completed after #138 landed the "neutralize-never-drop" sample-skipping fix. That fix addresses a *sample-dropping* path and does not cover the *empty-dispatch* path this PR guards.
- This is the only positive guard for `micro_batch_size`; the existing batch-size guard (`trainer.py:232`, USP-only `per_dp_rank_batch_size != 1`) rejects `0` only incidentally and only on the USP path.

## Change

- `torchspec/config/train_config.py`: add `_validate_training_batch_config(config)`, which raises `ValueError` when `training.micro_batch_size < 1`, with a message naming the field and the implication (empty dispatch → NCCL hang). Wired into `load_config()` next to the existing validators.
- No runtime/dispatch changes — the guard is at config load only.
- `tests/test_training_config_validation.py`: regression tests covering zero/negative rejection (via `load_config` and directly via the validator) and a positive control. Red on `main` (no validator → `load` does not raise → `assertRaises` fails); green on this branch.

The validator follows the same shape as the existing positivity check in `_validate_offline_config` (`inference.offline.num_engines must be positive`).

## Why fail-fast at config load (rather than at dispatch)

Config-load validation surfaces the misconfiguration immediately with a precise message, before any process/cluster state is spun up. A runtime guard at dispatch would report a far-removed symptom (NCCL timeout) hours into a run, indistinguishable from #126. This matches the repo's existing pattern of validating resolved configs in `load_config`.

## Notes for reviewers

- `base_config` (used by the new test) is a pre-existing `load_config` parameter; this PR does not change `load_config`'s signature.
- Existing configs in the repo all use `micro_batch_size` of 1 or 2, so this rejects no currently-valid configuration.

Closes the empty-dispatch root cause behind the #126 symptom.
