### PR TITLE
fix(draft): tolerate trailing returns from CUTE _flash_attn_fwd

### DIFF
--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -807,7 +807,7 @@ class TestDFlashVerifierNorm(unittest.TestCase):
         def _capture(**kwargs):
             seen["last_hidden_states"] = kwargs["last_hidden_states"]
             zero = torch.zeros((), device="cuda")
-            return zero, zero, zero, zero, zero, {}
+            return zero, zero, zero, zero, zero, {}, (zero, zero)
 
         trainer.model = _capture
         last_hidden_states = torch.randn(1, 3, 4, device="cuda")
@@ -835,7 +835,7 @@ class TestDFlashVerifierNorm(unittest.TestCase):
         def _capture(**kwargs):
             seen["last_hidden_states"] = kwargs["last_hidden_states"]
             zero = torch.zeros((), device="cuda")
-            return zero, zero, zero, zero, zero, {}
+            return zero, zero, zero, zero, zero, {}, (zero, zero)
 
         trainer.model = _capture
         last_hidden_states = torch.randn(1, 3, 4, device="cuda")
@@ -861,7 +861,7 @@ class TestDFlashVerifierNorm(unittest.TestCase):
         def _capture(**kwargs):
             seen["last_hidden_states"] = kwargs["last_hidden_states"]
             zero = torch.zeros((), device="cuda")
-            return zero, zero, zero, zero, zero, {}
+            return zero, zero, zero, zero, zero, {}, (zero, zero)
 
         trainer.model = _capture
         trainer._forward(

--- a/tests/test_flash_attn_fwd_compat.py
+++ b/tests/test_flash_attn_fwd_compat.py
@@ -1,0 +1,90 @@
+import importlib.abc
+import importlib.machinery
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+# torch is installed, but numba/wandb/omegaconf/ray are not, and the root
+# conftest only installs its mock finder when torch is ABSENT. So before any
+# torchspec import we install a restricted meta-path finder for the missing
+# tangential deps. flash_attn/cutlass are deliberately NOT mocked: llama3_eagle's
+# own try/except must see flash_attn fail so it sets _flash_attn_fwd = None, the
+# symbol this test patches explicitly (not mocked at import time).
+_MISSING = {"numba", "wandb", "omegaconf", "ray"}
+
+
+class _TangentialFinder(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        top = fullname.split(".", 1)[0]
+        if top not in _MISSING:
+            return None
+        return importlib.machinery.ModuleSpec(fullname, self, is_package=True)
+
+    def create_module(self, spec):
+        class _Proxy(types.ModuleType):
+            def __getattr__(self, name):
+                return MagicMock()
+
+        proxy = _Proxy(spec.name)
+        proxy.__path__ = []
+        proxy.__package__ = spec.name
+        if spec.name == "numba":
+            # no-op @njit passthrough: supports both @njit and @njit(...) forms.
+            def _njit(*args, **kwargs):
+                if len(args) == 1 and callable(args[0]) and not kwargs:
+                    return args[0]
+                return lambda fn: fn
+
+            proxy.njit = _njit
+        return proxy
+
+    def exec_module(self, module):
+        pass
+
+
+sys.meta_path.insert(0, _TangentialFinder())
+
+import torch  # noqa: E402
+
+import torchspec.models.draft.llama3_eagle as _mod  # noqa: E402
+from torchspec.models.draft.llama3_eagle import _EagleMaskedFlashAttnFunc  # noqa: E402
+
+
+def test_flash_attn_fwd_tolerates_trailing_returns():
+    """Regression for issue #170.
+
+    flash-attn 4.0.0b22 CUTE ``_flash_attn_fwd`` returns more than two values;
+    the rigid ``out, lse = _flash_attn_fwd(...)`` unpack raised
+    ``ValueError: too many values to unpack``. The fix uses
+    ``out, lse, *_rest = _flash_attn_fwd(...)`` so trailing returns are
+    tolerated (the backward consumes only the saved ``(q, k, v, out, lse)`` via
+    ``ctx.save_for_backward``).
+
+    On master this call raises ValueError (RED); on the fix branch it returns
+    ``out`` cleanly (GREEN).
+    """
+    q = torch.randn(1, 8, 2, 8, dtype=torch.float32)
+    k = torch.randn(1, 8, 2, 8, dtype=torch.float32)
+    v = torch.randn(1, 8, 2, 8, dtype=torch.float32)
+
+    def fake_fwd(*args, **kwargs):
+        # Mimic CUTE returning a trailing extra value beyond (out, lse).
+        return torch.randn_like(q), torch.randn(1, 2, 8, dtype=torch.float32), "extra_return"
+
+    with (
+        patch.object(_mod, "_flash_attn_fwd", fake_fwd),
+        patch.object(_mod, "_get_block_sparse", return_value=None),
+    ):
+        out = _EagleMaskedFlashAttnFunc.apply(
+            q,
+            k,
+            v,
+            mask_mod_cute=None,
+            mask_mod_flex=None,
+            softmax_scale=1.0,
+            max_seq_len=8,
+            aux_tensors=None,
+        )
+
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == q.shape

--- a/tests/test_flash_attn_fwd_compat.py
+++ b/tests/test_flash_attn_fwd_compat.py
@@ -1,79 +1,29 @@
-import importlib.abc
-import importlib.machinery
-import sys
-import types
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-# torch is installed, but numba/wandb/omegaconf/ray are not, and the root
-# conftest only installs its mock finder when torch is ABSENT. So before any
-# torchspec import we install a restricted meta-path finder for the missing
-# tangential deps. flash_attn/cutlass are deliberately NOT mocked: llama3_eagle's
-# own try/except must see flash_attn fail so it sets _flash_attn_fwd = None, the
-# symbol this test patches explicitly (not mocked at import time).
-_MISSING = {"numba", "wandb", "omegaconf", "ray"}
+import torch
 
-
-class _TangentialFinder(importlib.abc.MetaPathFinder):
-    def find_spec(self, fullname, path, target=None):
-        top = fullname.split(".", 1)[0]
-        if top not in _MISSING:
-            return None
-        return importlib.machinery.ModuleSpec(fullname, self, is_package=True)
-
-    def create_module(self, spec):
-        class _Proxy(types.ModuleType):
-            def __getattr__(self, name):
-                return MagicMock()
-
-        proxy = _Proxy(spec.name)
-        proxy.__path__ = []
-        proxy.__package__ = spec.name
-        if spec.name == "numba":
-            # no-op @njit passthrough: supports both @njit and @njit(...) forms.
-            def _njit(*args, **kwargs):
-                if len(args) == 1 and callable(args[0]) and not kwargs:
-                    return args[0]
-                return lambda fn: fn
-
-            proxy.njit = _njit
-        return proxy
-
-    def exec_module(self, module):
-        pass
-
-
-sys.meta_path.insert(0, _TangentialFinder())
-
-import torch  # noqa: E402
-
-import torchspec.models.draft.llama3_eagle as _mod  # noqa: E402
-from torchspec.models.draft.llama3_eagle import _EagleMaskedFlashAttnFunc  # noqa: E402
+import torchspec.models.draft.llama3_eagle as llama3_eagle
+from torchspec.models.draft.llama3_eagle import _EagleMaskedFlashAttnFunc
 
 
 def test_flash_attn_fwd_tolerates_trailing_returns():
-    """Regression for issue #170.
+    """Regression for #170.
 
-    flash-attn 4.0.0b22 CUTE ``_flash_attn_fwd`` returns more than two values;
-    the rigid ``out, lse = _flash_attn_fwd(...)`` unpack raised
-    ``ValueError: too many values to unpack``. The fix uses
-    ``out, lse, *_rest = _flash_attn_fwd(...)`` so trailing returns are
-    tolerated (the backward consumes only the saved ``(q, k, v, out, lse)`` via
-    ``ctx.save_for_backward``).
-
-    On master this call raises ValueError (RED); on the fix branch it returns
-    ``out`` cleanly (GREEN).
+    The CUTE ``_flash_attn_fwd`` returns more than ``(out, lse)``, which broke
+    the rigid ``out, lse = _flash_attn_fwd(...)`` unpack. The fix unpacks with
+    ``out, lse, *_rest`` so trailing returns are tolerated.
     """
-    q = torch.randn(1, 8, 2, 8, dtype=torch.float32)
-    k = torch.randn(1, 8, 2, 8, dtype=torch.float32)
-    v = torch.randn(1, 8, 2, 8, dtype=torch.float32)
+    q = torch.randn(1, 8, 2, 8)
+    k = torch.randn(1, 8, 2, 8)
+    v = torch.randn(1, 8, 2, 8)
 
     def fake_fwd(*args, **kwargs):
-        # Mimic CUTE returning a trailing extra value beyond (out, lse).
-        return torch.randn_like(q), torch.randn(1, 2, 8, dtype=torch.float32), "extra_return"
+        # Mimic CUTE returning a trailing value beyond (out, lse).
+        return torch.randn_like(q), torch.randn(1, 2, 8), "extra_return"
 
     with (
-        patch.object(_mod, "_flash_attn_fwd", fake_fwd),
-        patch.object(_mod, "_get_block_sparse", return_value=None),
+        patch.object(llama3_eagle, "_flash_attn_fwd", fake_fwd),
+        patch.object(llama3_eagle, "_get_block_sparse", return_value=None),
     ):
         out = _EagleMaskedFlashAttnFunc.apply(
             q,

--- a/torchspec/models/draft/llama3_eagle.py
+++ b/torchspec/models/draft/llama3_eagle.py
@@ -1656,7 +1656,7 @@ def _standard_flash_attn_forward(
     softmax_scale: float,
     causal: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    out, lse, _, _ = _std_flash_attn_forward(
+    out, lse, *_rest = _std_flash_attn_forward(
         q,
         k,
         v,

--- a/torchspec/models/draft/llama3_eagle.py
+++ b/torchspec/models/draft/llama3_eagle.py
@@ -1158,7 +1158,7 @@ class _EagleMaskedFlashAttnFunc(torch.autograd.Function):
             direction="kv",
         )
 
-        out, lse = _flash_attn_fwd(
+        out, lse, *_rest = _flash_attn_fwd(
             q,
             k,
             v,


### PR DESCRIPTION
Closes #170.

### Problem
With `flash-attn==4.0.0b22`, the CUTE-DSL `_flash_attn_fwd` returns more than two values from the forward call. `_EagleMaskedFlashAttnFunc.forward` unpacks exactly two:

```python
out, lse = _flash_attn_fwd(...)   # llama3_eagle.py:1161
```

so any CUTE-masked Eagle3 forward raises at runtime:

```
ValueError: too many values to unpack (expected 2, got 3)
```

This breaks the CUTE masked-attention path (the default when `flash_attn.cute` is available) on the affected flash-attn builds. The reporter is already shipping a local `sed` patch as a workaround.

### Fix
Tolerate trailing return values, matching the trailing-value tolerance the same file already uses for the standard flash-attn path:

```python
out, lse, *_rest = _flash_attn_fwd(...)   # :1161
```

(The standard path at `:1659` uses a fixed 4-tuple `out, lse, _, _ = _std_flash_attn_forward(...)`; `*_rest` here is strictly more tolerant — it accepts 2 or more returns.)

- One-line change to the single rigid CUTE unpack site.
- Forward/backward compatible: older builds that return exactly two values still unpack correctly (`*_rest` is empty).
- The backward (`llama3_eagle.py:1192`) consumes only the saved `(q, k, v, out, lse)` via `ctx.save_for_backward`, so the discarded trailing values are never read.

### Why a minimal compat fix rather than extending LlamaFlexAttention
The CUTE masked path is the path being converged off for FlexAttention/FA4 (roadmap #30, #86). A reasonable review question is whether this fix just prolongs the dead path instead of extending `LlamaFlexAttention`.

This PR is intentionally scoped to the compat fix only, because:

1. **It stops a live user-facing crash today.** Issue #170 reports a hard `ValueError` on a released flash-attn build; users on that build cannot run the CUTE path at all. The one-line fix restores it immediately.
2. **It does not block or steer the FlexAttention migration.** The change is additive tolerance, not new surface; removing the CUTE path later (once FlexAttention parity lands) remains a clean deletion — this fix adds nothing to delete.
3. **Extending `LlamaFlexAttention` to cover the CUTE path's cases is a larger, behavioral-change PR** (mask parity, perf parity, backward coverage) that should be designed and benchmarked on its own, not bundled into a crash fix. The maintainers' own prior art (the trailing-value tolerance at `:1659`, `out, lse, _, _ = _std_flash_attn_forward(...)`) signals the accepted pattern for tolerating extra returns from the flash-attn forward.

### Tests
New `tests/test_flash_attn_fwd_compat.py` reproduces the bug and the fix without requiring a real flash-attn install:
- Stubs the tangential `numba`/`wandb`/`omegaconf`/`ray` imports so the module loads on minimal dev machines (mirrors the repo `conftest.py` mock-finder philosophy; does not touch flash_attn).
- Patches `llama3_eagle._flash_attn_fwd` to return a 3-tuple `(out, lse, extra)` and `_get_block_sparse` to a no-op, then calls `_EagleMaskedFlashAttnFunc.apply(...)` with small real `torch` tensors.

Behavior:
- **master (rigid unpack):** `ValueError: too many values to unpack (expected 2, got 3)` at `llama3_eagle.py:1161`.
- **this branch (variadic unpack):** returns the output tensor without error.

The function under fix (`_EagleMaskedFlashAttnFunc.forward`) is exercised for real — only the external `_flash_attn_fwd` dependency is patched.

### Checklist
- [x] Change scoped to the single unpack line in `torchspec/models/draft/llama3_eagle.py`
- [x] Backward method and dispatch logic untouched
- [x] Regression test added (red on master / green on branch)
- [x] `ruff check` clean
- [x] References #170