### PR TITLE
ci: publish nightly multi-arch Docker image

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -1,0 +1,158 @@
+name: Publish Nightly Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Optional Docker image tag. Defaults to nightly-<short SHA>-vllm-v0.22.1.
+        required: false
+        type: string
+
+concurrency:
+  group: publish-nightly-docker-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  IMAGE: lightseekorg/torchspec
+  VLLM_VERSION: v0.22.1
+
+jobs:
+  build:
+    if: github.repository == 'lightseekorg/TorchSpec'
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            artifact: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            artifact: linux-arm64
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/vllm/v0.22.1/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          no-cache: true
+          provenance: false
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=nightly-${{ github.sha }}-vllm-${{ env.VLLM_VERSION }}
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.artifact }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    if: github.repository == 'lightseekorg/TorchSpec'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digests-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Derive image tags
+        id: tags
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          immutable_tag="${INPUT_TAG:-nightly-${GITHUB_SHA::7}-vllm-${VLLM_VERSION}}"
+          moving_tag="nightly-vllm-${VLLM_VERSION}"
+          for tag in "$immutable_tag" "$moving_tag"; do
+            if [[ ! "$tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+              echo "::error::Invalid image tag: ${tag}" >&2
+              exit 1
+            fi
+          done
+          echo "immutable=${immutable_tag}" >> "$GITHUB_OUTPUT"
+          echo "moving=${moving_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Create multi-platform manifest
+        env:
+          IMMUTABLE_TAG: ${{ steps.tags.outputs.immutable }}
+          MOVING_TAG: ${{ steps.tags.outputs.moving }}
+        run: |
+          refs=()
+          for digest in "${RUNNER_TEMP}"/digests/*; do
+            refs+=("${IMAGE}@sha256:$(basename "${digest}")")
+          done
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${IMMUTABLE_TAG}" \
+            --tag "${IMAGE}:${MOVING_TAG}" \
+            "${refs[@]}"
+
+      - name: Publish job summary
+        env:
+          IMMUTABLE_TAG: ${{ steps.tags.outputs.immutable }}
+          MOVING_TAG: ${{ steps.tags.outputs.moving }}
+        run: |
+          digest=$(docker buildx imagetools inspect "${IMAGE}:${IMMUTABLE_TAG}" | awk '$1 == "Digest:" {print $2; exit}')
+          {
+            echo "### Published TorchSpec image"
+            echo
+            echo "- Immutable: \`${IMAGE}:${IMMUTABLE_TAG}\`"
+            echo "- Moving: \`${IMAGE}:${MOVING_TAG}\`"
+            echo "- Digest: \`${digest}\`"
+            echo "- Platforms: \`linux/amd64\`, \`linux/arm64\`"
+            echo "- TorchSpec commit: \`${GITHUB_SHA}\`"
+            echo "- vLLM base: \`${VLLM_VERSION}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- add a manually dispatched nightly TorchSpec Docker publisher
- build `linux/amd64` and `linux/arm64` natively on GitHub-hosted runners
- push each platform by digest and combine them into one Docker Hub manifest
- publish an immutable `nightly-<short-sha>-vllm-v0.22.1` tag plus the moving `nightly-vllm-v0.22.1` tag
- record the manifest digest, platforms, TorchSpec commit, and vLLM base in the job summary

## Why

TorchSpec currently has a release-only Docker workflow, but no image has been published under `lightseekorg/torchspec`. This provides a first, reproducible nightly image for both x86 NVIDIA hosts and ARM64 GB200/Grace hosts, following the same per-platform digest and manifest pattern used by tokenspeed.

The workflow is manual initially so the first large multi-architecture build can be qualified before enabling a scheduled run.

## Validation

- `pre-commit run --all-files --show-diff-on-failure`
- `actionlint .github/workflows/docker-nightly.yml`
- `git diff --check`

## Deployment prerequisite

Create the public Docker Hub repository `lightseekorg/torchspec` if the configured service account cannot create it on first push. The existing `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` GitHub Actions secrets are used only by this trusted manual workflow.
