### PR TITLE
fix(config): reject non-positive numeric training-config fields at load

### DIFF
--- a/tests/test_training_config_validation.py
+++ b/tests/test_training_config_validation.py
@@ -1,4 +1,4 @@
-"""Regression tests for training batch-size validation at config load.
+"""Regression tests for training-config validation at config load.
 
 Guards the empty-dispatch NCCL-hang root cause behind the issue #126 surface:
 a ``training.micro_batch_size`` of 0 makes the derived ``dispatch_batch_size`` 0,
@@ -6,6 +6,14 @@ so ``try_dispatch_batch`` no-op-dispatches (returns True while queuing nothing)
 and every rank blocks on the data-fetcher queue, surfacing as an NCCL
 all-gather timeout. The validator rejects non-positive sizes at config load,
 before any training process starts.
+
+Extends the same fail-closed-at-load idiom (PR #171) to four more numeric
+fields whose non-positive values currently fail *silently* (flat loss from
+``learning_rate=0`` / ``max_grad_norm=0``, sign-flipped gradients from
+``max_grad_norm<0``, inference-pool starvation from ``inference_batch_size=0``)
+or crash *opaquely and late* (post-init ``ZeroDivisionError`` / bare
+``total_steps`` assert from ``draft_accumulation_steps<=0``). Rejecting at
+load surfaces the misconfig before Ray/mooncake/vLLM init.
 """
 
 import pytest
@@ -57,3 +65,82 @@ def test_validate_training_batch_config_accepts_positive():
 
     config = _resolved_config(micro_batch_size=8)
     _validate_training_batch_config(config)  # must not raise
+
+
+# --- Numeric training-config fields (draft_accumulation_steps, learning_rate,
+#     max_grad_norm) and inference_batch_size — PR #171 idiom extended. ---
+
+
+def _resolved_training_config(**overrides):
+    """Build a fully-resolved config from the schema defaults + training overrides."""
+    config = OmegaConf.structured(Config)
+    for key, value in overrides.items():
+        setattr(config.training, key, value)
+    return config
+
+
+def _resolved_inference_config(inference_batch_size: int):
+    """Build a fully-resolved config from the schema defaults + an inference-batch override."""
+    config = OmegaConf.structured(Config)
+    config.inference.inference_batch_size = inference_batch_size
+    return config
+
+
+def test_load_config_rejects_zero_draft_accumulation_steps():
+    """draft_accumulation_steps=0 must fail at load: propagates to global_batch_size=0
+    and crashes post-init (ZeroDivisionError or bare total_steps assert)."""
+    base = _resolved_training_config(draft_accumulation_steps=0)
+    with pytest.raises(ValueError, match="draft_accumulation_steps"):
+        load_config(base_config=base)
+
+
+def test_load_config_rejects_negative_draft_accumulation_steps():
+    """Negative values propagate the same way and must be rejected at load."""
+    base = _resolved_training_config(draft_accumulation_steps=-2)
+    with pytest.raises(ValueError, match="draft_accumulation_steps"):
+        load_config(base_config=base)
+
+
+def test_load_config_rejects_zero_learning_rate():
+    """learning_rate=0 yields silent flat loss (AdamW+scheduler at lr=0) and an
+    untrained checkpoint; reject at load."""
+    base = _resolved_training_config(learning_rate=0)
+    with pytest.raises(ValueError, match="learning_rate"):
+        load_config(base_config=base)
+
+
+def test_load_config_rejects_negative_learning_rate():
+    """Negative learning rates hit a late scheduler assert; reject at load."""
+    base = _resolved_training_config(learning_rate=-1e-4)
+    with pytest.raises(ValueError, match="learning_rate"):
+        load_config(base_config=base)
+
+
+def test_load_config_rejects_zero_max_grad_norm():
+    """max_grad_norm=0 zeroes all grads via clip_grad_norm_ (silent flat loss);
+    reject at load."""
+    base = _resolved_training_config(max_grad_norm=0)
+    with pytest.raises(ValueError, match="max_grad_norm"):
+        load_config(base_config=base)
+
+
+def test_load_config_rejects_negative_max_grad_norm():
+    """Negative max_grad_norm sign-flips grads (silent gradient ascent); reject at load."""
+    base = _resolved_training_config(max_grad_norm=-0.5)
+    with pytest.raises(ValueError, match="max_grad_norm"):
+        load_config(base_config=base)
+
+
+def test_load_config_rejects_zero_inference_batch_size():
+    """inference_batch_size=0 starves the inference pool (silent dispatch spin) and
+    vLLM rejects max_num_seqs=0 late after init; reject at load."""
+    base = _resolved_inference_config(inference_batch_size=0)
+    with pytest.raises(ValueError, match="inference_batch_size"):
+        load_config(base_config=base)
+
+
+def test_load_config_rejects_negative_inference_batch_size():
+    """Negative inference batch sizes starve the pool the same way; reject at load."""
+    base = _resolved_inference_config(inference_batch_size=-1)
+    with pytest.raises(ValueError, match="inference_batch_size"):
+        load_config(base_config=base)

--- a/torchspec/config/inference_config.py
+++ b/torchspec/config/inference_config.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
+from omegaconf import DictConfig
+
 from torchspec.config.mooncake_config import MooncakeConfig
 
 
@@ -198,3 +200,12 @@ class HFInferenceConfig:
     trust_remote_code: bool = False
     aux_hidden_states_layers: Optional[list[int]] = None
     mooncake_config: Optional[MooncakeConfig] = None
+
+
+def _validate_inference_batch_config(config: DictConfig) -> None:
+    if config.inference.inference_batch_size <= 0:
+        raise ValueError(
+            f"inference_batch_size must be > 0 (got {config.inference.inference_batch_size}); "
+            f"0 causes inference-pool starvation (silent dispatch spin) and vLLM rejects "
+            f"max_num_seqs=0 late after init"
+        )

--- a/torchspec/config/train_config.py
+++ b/torchspec/config/train_config.py
@@ -26,7 +26,7 @@ from typing import Any, Optional
 
 from omegaconf import DictConfig, OmegaConf
 
-from torchspec.config.inference_config import InferenceConfig
+from torchspec.config.inference_config import InferenceConfig, _validate_inference_batch_config
 from torchspec.data.utils import is_local_data_path
 from torchspec.utils.logging import logger
 
@@ -300,6 +300,31 @@ def _validate_training_batch_config(config: DictConfig) -> None:
         )
 
 
+def _validate_training_numeric_config(config: DictConfig) -> None:
+    """Reject non-positive values that would otherwise fail silently or crash late.
+
+    These fields share the fail-closed-at-load principle of #171: a misconfig that
+    produces flat loss, sign-flipped gradients, or an opaque post-init crash is
+    preferable to surfacing after expensive Ray/mooncake init.
+    """
+    if config.training.draft_accumulation_steps <= 0:
+        raise ValueError(
+            f"draft_accumulation_steps must be > 0 (got {config.training.draft_accumulation_steps}); "
+            f"<=0 propagates into global_batch_size/lr_total_steps and crashes post-init "
+            f"(ZeroDivisionError or bare total_steps assert)"
+        )
+    if config.training.learning_rate <= 0:
+        raise ValueError(
+            f"learning_rate must be > 0 (got {config.training.learning_rate}); "
+            f"0 yields silent flat loss (untrained checkpoint), <0 hits a late assert"
+        )
+    if config.training.max_grad_norm <= 0:
+        raise ValueError(
+            f"max_grad_norm must be > 0 (got {config.training.max_grad_norm}); "
+            f"0 zeroes all grads (silent flat loss), <0 sign-flips grads (silent gradient ascent)"
+        )
+
+
 def _save_config_snapshot(config: DictConfig) -> None:
     """Save the resolved config to output_dir/config.yaml if output_dir is set."""
     output_dir = OmegaConf.select(config, "output_dir", default=None)
@@ -347,6 +372,8 @@ def load_config(
     _validate_offline_config(config)
     _validate_vocab_mapping_config(config)
     _validate_training_batch_config(config)
+    _validate_training_numeric_config(config)
+    _validate_inference_batch_config(config)
 
     if save_snapshot:
         _save_config_snapshot(config)


### PR DESCRIPTION
## Summary

Extends the fail-closed `_validate_training_batch_config` idiom from #171
(`micro_batch_size`) to four more numeric training-config fields whose
non-positive values currently cause **silent failures** (no error, run exits
"successfully" with bad state) or **opaque late crashes** (after minutes of
Ray / placement-group / Mooncake init, with a traceback that does not point
at the config knob). All four are rejected at `load_config` time, before any
training process starts — the same place #171 already guards `micro_batch_size`.

| field | file | non-positive value → |
|-------|------|----------------------|
| `training.draft_accumulation_steps` | `train_config.py` | `0` → `global_batch_size=0` → `ZeroDivisionError` at `setup.py` after Ray/Mooncake init; `<0` propagates into `lr_total_steps` → bare `assert total_steps > 0` (`lr_scheduler.py`) inside a trainer actor, no message |
| `training.learning_rate` | `train_config.py` | `0` → `AdamW(lr=0)` + scheduler with `max_lr=min_lr=0`; the `max_lr >= min_lr` assert *passes* for `0 >= 0`, so the run produces a flat loss and exits successfully with an **untrained checkpoint**; `<0` hits a late bare assert |
| `training.max_grad_norm` | `train_config.py` | `0` → `clip_grad_norm_` `clip_coef=0` zeroes every gradient (silent flat loss); `<0` → negative `clip_coef` **sign-flips** gradients (silent gradient ascent). Both return a finite `grad_norm`, so the `found_inf` guard never trips and `optimizer.step()` proceeds |
| `inference.inference_batch_size` | `inference_config.py` | `0` → the inference manager dispatches 0 prompts per tick, the pool never fills, `try_dispatch_batch` returns `False` and the training loop spins silently; vLLM also receives `max_num_seqs=inference_batch_size` and rejects `0` late via a `RuntimeError` after init |

## Why fail-closed-at-load (vs. "the user will notice")

The natural objection is that these are "obvious misconfigs" a user catches
from a flat wandb curve or a visible engine error. In practice on a
multi-node run that objection does not hold:

- **Silent ≠ visible.** `learning_rate=0` and `max_grad_norm=0` produce a
  *finite, flat* loss with no exception — the run completes and saves a
  checkpoint that looks superficially healthy. The bad config is discovered
  only on eval, hours later. `max_grad_norm<0` is worse: the loss *moves*
  (gradient ascent), so "flat curve" heuristics do not fire either.
- **Late ≠ cheap.** `draft_accumulation_steps<=0` and the vLLM
  `max_num_seqs=0` rejection both fire *after* placement-group creation,
  Mooncake store init, and dataset preprocessing — minutes of multi-node
  setup, with a traceback pointing at `setup.py` / the engine, not the YAML
  knob the user mistyped.
- **Consistency.** #171 already chose fail-closed-at-load for the sibling
  field `micro_batch_size` for exactly this reason ("empty-dispatch NCCL-hang
  root cause"). This PR applies the same boundary to the other numeric fields
  that share the silent/late failure shape, rather than guarding one and
  leaving four identical traps open.

This matches the project's existing `_validate_*` cluster
(`_validate_vllm_config`, `_validate_vocab_mapping_config`,
`_validate_offline_config`, `_validate_training_batch_config`) — all of which
reject bad config at load rather than letting it surface deep in a trainer
actor.

## Changes

- `torchspec/config/train_config.py`: add `_validate_training_numeric_config`
  rejecting `<= 0` for `draft_accumulation_steps`, `learning_rate`, and
  `max_grad_norm`; wire it into `load_config` immediately after
  `_validate_training_batch_config`.
- `torchspec/config/inference_config.py`: add `_validate_inference_batch_config`
  rejecting `<= 0` for `inference_batch_size`.
- `tests/test_training_config_validation.py`: 8 new tests (reject `0` and
  reject a negative value for each of the four fields), mirroring the existing
  `test_load_config_rejects_zero_micro_batch_size` pattern. The 5 existing
  `micro_batch_size` tests are unchanged.

Error messages name the field so the failing knob is identifiable from the
traceback (e.g. `learning_rate must be > 0 (got 0); 0 yields silent flat
loss (untrained checkpoint), <0 hits a late assert`).

## Validation

- `python -m pytest tests/test_training_config_validation.py -v` → 13 passed
  (5 existing + 8 new).
- Red-on-master verified: with the two source files reverted to `main` and
  the test file kept, all 8 new tests FAIL (`DID NOT RAISE`) — i.e. `main`'s
  `load_config` does not reject these values.
- `ruff check` + `ruff format --check` clean. `pyproject.toml` `[tool.ruff]`
  untouched.

## Scope

Only `torchspec/config/train_config.py`, `torchspec/config/inference_config.py`,
and `tests/test_training_config_validation.py`. No CI / pre-commit / Docker /
`tools/ci` changes (those are being added separately in #173).

Follows #171. /cc @Dogacel